### PR TITLE
fix: four silent failures — stale dist, CLI auth, daemon health, condensation

### DIFF
--- a/dist/db/connection.js
+++ b/dist/db/connection.js
@@ -5,17 +5,134 @@
  */
 import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
-import { open } from "sqlite";
-import sqlite3 from "sqlite3";
+/**
+ * We deliberately depend on the built-in `node:sqlite` rather than the
+ * `sqlite3` npm package. Plugin hosts install plugins with `--ignore-scripts`,
+ * which silently skips `sqlite3`'s native `install` step
+ * (`prebuild-install -r napi || node-gyp rebuild`). The result is a package
+ * tree with sources but no `node_sqlite3.node`, so every daemon start dies on
+ * "Could not locate the bindings file". A built-in has no install step to skip.
+ *
+ * The cost is a Node floor: `node:sqlite` landed in 22.5.0.
+ */
+const MIN_NODE_VERSION_FOR_SQLITE = "22.5.0";
+/** Prepared statements are cached per SQL text; the hot lookup path re-runs a
+ * small, fixed set of queries and re-preparing each time is pure overhead. */
+const STATEMENT_CACHE_LIMIT = 256;
 export async function createCodeMemoryDatabaseConnection(dbPath) {
     const dbDir = dirname(dbPath);
     await mkdir(dbDir, { recursive: true });
-    const db = await open({
-        filename: dbPath,
-        driver: sqlite3.Database,
+    const { DatabaseSync: Database } = await loadNodeSqlite();
+    const handle = new Database(dbPath, {
+        // The daemon and the one-shot fallback CLI can touch the same file
+        // concurrently. Without a busy timeout `node:sqlite` fails immediately on
+        // SQLITE_BUSY instead of waiting for the other writer to finish.
+        timeout: 5000,
+        // SQLite (and therefore the previous `sqlite3` driver) leaves foreign key
+        // enforcement OFF by default; `node:sqlite` turns it ON. Every table here
+        // was written against the unenforced default — nodes are routinely
+        // inserted before the conversation row they reference — so enabling it
+        // would turn the driver swap into a schema change.
+        enableForeignKeyConstraints: false,
     });
+    const db = createDatabaseAdapter(handle);
     await runCodeMemoryMigrations(db);
     return db;
+}
+/**
+ * Loads the built-in lazily so an unsupported Node version produces an
+ * actionable message instead of a bare ERR_UNKNOWN_BUILTIN_MODULE stack.
+ */
+async function loadNodeSqlite() {
+    try {
+        return await import("node:sqlite");
+    }
+    catch (error) {
+        throw new Error(`[codememory] CodeMemory requires Node >= ${MIN_NODE_VERSION_FOR_SQLITE} ` +
+            `for the built-in node:sqlite module (found ${process.version}). ` +
+            `Upgrade Node and restart the session.`, { cause: error });
+    }
+}
+export function createDatabaseAdapter(handle) {
+    const statements = new Map();
+    function prepare(sql) {
+        const cached = statements.get(sql);
+        if (cached)
+            return cached;
+        const statement = handle.prepare(sql);
+        if (statements.size >= STATEMENT_CACHE_LIMIT) {
+            // FIFO eviction: insertion order is good enough for a fixed query set.
+            const oldest = statements.keys().next();
+            if (!oldest.done)
+                statements.delete(oldest.value);
+        }
+        statements.set(sql, statement);
+        return statement;
+    }
+    return {
+        async exec(sql) {
+            handle.exec(sql);
+        },
+        async run(sql, ...params) {
+            const result = prepare(sql).run(...bindParams(params));
+            return {
+                lastID: Number(result.lastInsertRowid),
+                changes: Number(result.changes),
+            };
+        },
+        async get(sql, ...params) {
+            const row = prepare(sql).get(...bindParams(params));
+            return row === undefined ? undefined : toPlainRow(row);
+        },
+        async all(sql, ...params) {
+            return prepare(sql)
+                .all(...bindParams(params))
+                .map((row) => toPlainRow(row));
+        },
+        async close() {
+            statements.clear();
+            handle.close();
+        },
+    };
+}
+/**
+ * Call sites use both `run(sql, a, b)` and `run(sql, [a, b])`; the previous
+ * `sqlite` wrapper accepted either, so we keep accepting both.
+ */
+function bindParams(params) {
+    const flat = params.length === 1 && Array.isArray(params[0])
+        ? params[0]
+        : params;
+    return flat.map(normalizeParam);
+}
+/**
+ * `node:sqlite` throws on values the old `sqlite3` driver coerced silently.
+ * Reproducing that coercion here keeps the migration behavior-preserving —
+ * without it, any code path that binds an optional field would start throwing
+ * "Provided value cannot be bound to SQLite parameter N" at runtime.
+ */
+function normalizeParam(value) {
+    if (value === undefined || value === null)
+        return null;
+    if (typeof value === "boolean")
+        return value ? 1 : 0;
+    if (value instanceof Date)
+        return value.toISOString();
+    if (typeof value === "number")
+        return Number.isFinite(value) ? value : null;
+    if (typeof value === "string" ||
+        typeof value === "bigint" ||
+        value instanceof Uint8Array) {
+        return value;
+    }
+    throw new TypeError(`[codememory] Cannot bind ${typeof value} to a SQLite parameter: ${String(value)}`);
+}
+/**
+ * Rows come back with a null prototype. Callers spread and JSON-serialize
+ * them, so hand back ordinary objects to match the previous driver.
+ */
+function toPlainRow(row) {
+    return Object.assign({}, row);
 }
 export async function runCodeMemoryMigrations(db) {
     // Migration 1: Create conversations table
@@ -364,6 +481,15 @@ async function ensureMemoryNodeKindSupport(db) {
     const sql = String(table?.sql || "");
     if (sql.includes("'task'") && sql.includes("'constraint'"))
         return;
+    // The table rebuild below drops and renames `memory_nodes`, so foreign key
+    // enforcement has to come off for the duration. Capture the current setting
+    // rather than assuming it: this migration only runs for databases created
+    // before kind='task'/'constraint' existed, and unconditionally restoring it
+    // to ON left those sessions enforcing foreign keys while freshly created
+    // databases did not — the same connection behaving two different ways
+    // depending on how old the file on disk was.
+    const foreignKeysPragma = (await db.get("PRAGMA foreign_keys"));
+    const foreignKeysWereEnabled = (foreignKeysPragma?.foreign_keys ?? 0) === 1;
     await db.exec("PRAGMA foreign_keys = OFF");
     try {
         await db.exec("BEGIN TRANSACTION");
@@ -431,7 +557,7 @@ async function ensureMemoryNodeKindSupport(db) {
         throw error;
     }
     finally {
-        await db.exec("PRAGMA foreign_keys = ON");
+        await db.exec(`PRAGMA foreign_keys = ${foreignKeysWereEnabled ? "ON" : "OFF"}`);
     }
 }
 export async function getCodeMemoryDbFeatures(db) {

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -33,6 +33,16 @@ echo "[$(date -Iseconds)] Initializing database" >> "$LOG_FILE"
 echo "[$(date -Iseconds)] Starting JSONL watcher daemon" >> "$LOG_FILE"
 echo "[$(date -Iseconds)] CLAUDE_PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-}" >> "$LOG_FILE"
 
+# Spawning the daemon is not the same as having a daemon. A crash on startup
+# (a missing native binding, an unreadable database, an unsupported Node) exits
+# within milliseconds, and reporting "initialized" over a dead process is how a
+# 100% daemon failure rate stayed invisible for months. The socket is the only
+# honest readiness signal: nothing can be looked up until it exists.
+DAEMON_HEALTH_TIMEOUT="${CODEMEMORY_DAEMON_HEALTH_TIMEOUT:-3}"
+DAEMON_HEALTH_POLL_INTERVAL="0.1"
+DAEMON_HEALTHY="false"
+DAEMON_FAILURE_REASON=""
+
 if command -v node >/dev/null 2>&1 && [ -d "${CLAUDE_PLUGIN_ROOT}/dist" ]; then
     echo "[$(date -Iseconds)] Node and dist found, starting daemon" >> "$LOG_FILE"
     cd "${CLAUDE_PLUGIN_ROOT}"
@@ -43,8 +53,41 @@ if command -v node >/dev/null 2>&1 && [ -d "${CLAUDE_PLUGIN_ROOT}/dist" ]; then
         </dev/null >>"${LOG_DIR}/daemon.log" 2>&1 &
     DAEMON_PID=$!
     disown "$DAEMON_PID" 2>/dev/null || true
-    echo "[$(date -Iseconds)] Daemon started with PID $DAEMON_PID" >> "$LOG_FILE"
+    echo "[$(date -Iseconds)] Daemon spawned with PID $DAEMON_PID" >> "$LOG_FILE"
+
+    # Poll for readiness, but abandon the wait the instant the process dies so
+    # a crash-on-start costs ~100ms rather than the full timeout.
+    SOCKET_PATH="${HOME}/.claude/codememory-runtime/${SESSION_ID}.sock"
+    DAEMON_HEALTH_MAX_POLLS=$(awk -v t="$DAEMON_HEALTH_TIMEOUT" -v i="$DAEMON_HEALTH_POLL_INTERVAL" \
+        'BEGIN { n = int(t / i); print (n < 1 ? 1 : n) }')
+    POLL=0
+    while [ "$POLL" -lt "$DAEMON_HEALTH_MAX_POLLS" ]; do
+        if [ -S "$SOCKET_PATH" ]; then
+            DAEMON_HEALTHY="true"
+            break
+        fi
+        if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+            DAEMON_FAILURE_REASON="the daemon exited during startup"
+            break
+        fi
+        sleep "$DAEMON_HEALTH_POLL_INTERVAL"
+        POLL=$((POLL + 1))
+    done
+
+    if [ "$DAEMON_HEALTHY" = "true" ]; then
+        echo "[$(date -Iseconds)] Daemon healthy, socket at $SOCKET_PATH" >> "$LOG_FILE"
+    else
+        if [ -z "$DAEMON_FAILURE_REASON" ]; then
+            DAEMON_FAILURE_REASON="the daemon did not open its socket within ${DAEMON_HEALTH_TIMEOUT}s"
+        fi
+        echo "[$(date -Iseconds)] DAEMON UNHEALTHY: $DAEMON_FAILURE_REASON" >> "$LOG_FILE"
+        # The daemon's own stderr is the only place the real cause appears;
+        # copy the tail next to this failure so both live in one log.
+        echo "[$(date -Iseconds)] Last lines of daemon.log:" >> "$LOG_FILE"
+        tail -n 5 "${LOG_DIR}/daemon.log" 2>/dev/null >> "$LOG_FILE" || true
+    fi
 else
+    DAEMON_FAILURE_REASON="node or ${CLAUDE_PLUGIN_ROOT}/dist was not found"
     echo "[$(date -Iseconds)] Node or dist not found! Node=$(command -v node 2>&1), dist=${CLAUDE_PLUGIN_ROOT}/dist" >> "$LOG_FILE"
 fi
 
@@ -54,22 +97,24 @@ echo "[$(date -Iseconds)] PROJECT_HASH=$PROJECT_HASH" >> "$LOG_FILE"
 HAS_HISTORY=$("${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-history.sh" "$PROJECT_HASH" || echo "false")
 echo "[$(date -Iseconds)] HAS_HISTORY=$HAS_HISTORY" >> "$LOG_FILE"
 
-# Build system message
-SYSTEM_MESSAGE="CodeMemory initialized. "
+# Build system message. Only claim initialization when the daemon is actually
+# serving; otherwise say so plainly and point at the log that holds the cause.
+if [ "$DAEMON_HEALTHY" = "true" ]; then
+    SYSTEM_MESSAGE="CodeMemory initialized. "
 
-if [ "$HAS_HISTORY" = "true" ]; then
-    SYSTEM_MESSAGE="${SYSTEM_MESSAGE}Found existing conversation history for this project. Use /codememory-grep to search, /codememory-expand-query to ask questions, or /codememory-status to view status."
+    if [ "$HAS_HISTORY" = "true" ]; then
+        SYSTEM_MESSAGE="${SYSTEM_MESSAGE}Found existing conversation history for this project. Use /codememory-grep to search, /codememory-expand-query to ask questions, or /codememory-status to view status."
+    else
+        SYSTEM_MESSAGE="${SYSTEM_MESSAGE}New project session. Conversation will be automatically saved to the CodeMemory database."
+    fi
 else
-    SYSTEM_MESSAGE="${SYSTEM_MESSAGE}New project session. Conversation will be automatically saved to the CodeMemory database."
+    SYSTEM_MESSAGE="CodeMemory is NOT running: ${DAEMON_FAILURE_REASON}. Nothing will be recorded and no prior-failure warnings will be injected this session. See ${LOG_DIR}/daemon.log for the cause."
 fi
 
-echo "[$(date -Iseconds)] Done, systemMessage=$SYSTEM_MESSAGE" >> "$LOG_FILE"
+echo "[$(date -Iseconds)] Done, daemonHealthy=$DAEMON_HEALTHY, systemMessage=$SYSTEM_MESSAGE" >> "$LOG_FILE"
 
-# Output hook result
-cat <<EOF
-{
-  "continue": true,
-  "suppressOutput": false,
-  "systemMessage": "$SYSTEM_MESSAGE"
-}
-EOF
+# Output hook result. `continue` stays true even when the daemon is dead — a
+# broken memory system must never block the user's session. Built with jq so a
+# failure reason containing quotes or newlines cannot produce invalid JSON.
+jq -n --arg msg "$SYSTEM_MESSAGE" \
+    '{continue: true, suppressOutput: false, systemMessage: $msg}'

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -584,6 +584,18 @@ async function ensureMemoryNodeKindSupport(db: any): Promise<void> {
   const sql = String(table?.sql || "");
   if (sql.includes("'task'") && sql.includes("'constraint'")) return;
 
+  // The table rebuild below drops and renames `memory_nodes`, so foreign key
+  // enforcement has to come off for the duration. Capture the current setting
+  // rather than assuming it: this migration only runs for databases created
+  // before kind='task'/'constraint' existed, and unconditionally restoring it
+  // to ON left those sessions enforcing foreign keys while freshly created
+  // databases did not — the same connection behaving two different ways
+  // depending on how old the file on disk was.
+  const foreignKeysPragma = (await db.get("PRAGMA foreign_keys")) as
+    | { foreign_keys: number }
+    | undefined;
+  const foreignKeysWereEnabled = (foreignKeysPragma?.foreign_keys ?? 0) === 1;
+
   await db.exec("PRAGMA foreign_keys = OFF");
   try {
     await db.exec("BEGIN TRANSACTION");
@@ -653,7 +665,9 @@ async function ensureMemoryNodeKindSupport(db: any): Promise<void> {
     await db.exec("ROLLBACK");
     throw error;
   } finally {
-    await db.exec("PRAGMA foreign_keys = ON");
+    await db.exec(
+      `PRAGMA foreign_keys = ${foreignKeysWereEnabled ? "ON" : "OFF"}`
+    );
   }
 }
 


### PR DESCRIPTION
Follow-up to #3. That PR fixed the source but left `main` shipping broken code — and investigating why turned up three more subsystems that had been failing without ever saying so.

Every problem here shares one shape: **the code reported what it attempted, not what happened.** A dead daemon reported "initialized". A failed LLM call logged a blank reason. A condensation pass that discarded every batch logged the batch count as if they had been written.

---

## 1. `main` is still dead on arrival

`main` commits compiled JS under `dist/` for marketplace releases. #3 changed `src/`, but nothing rebuilt `dist/`:

| File on `main` | State |
|---|---|
| `package.json` | dependencies are `@sinclair/typebox` only — `sqlite3` removed ✅ |
| `dist/db/connection.js` | still `import sqlite3 from "sqlite3"` ❌ |

Marketplace installs run the committed `dist/`, so every install still fails on session start — it just traded `Could not locate the bindings file` for `Cannot find module 'sqlite3'`.

Rebuilding touches exactly one file, which also confirms the rest of the committed `dist/` was already in sync.

> Because `dist/` is tracked, every `src` change needs a rebuild committed alongside it. The failure is invisible locally, where `dist/` is rebuilt on demand — which is precisely how it slipped through.

## 2. Every LLM-backed feature was dead, and none of them said so

All four spawn sites — compaction summaries, the query planner, the decision supersede judge, expansion delegation — passed `--bare`. The intent was sound: `--bare` skips hooks, and a child that replays our own SessionStart starts a second daemon against the same database.

But `--bare` also stops the CLI reading the keychain, and documents that Anthropic auth is then *strictly* `ANTHROPIC_API_KEY` or an apiKeyHelper. Anyone signed in through OAuth — every subscription user — got exit code 1 on every call:

```
$ printf 'Say OK' | claude --bare --print --output-format text
exit=1   stdout: "Not logged in · Please run /login"

$ printf 'Say OK' | claude --print --output-format text
exit=0   stdout: "OK"
```

The CLI prints that refusal **on stdout with an empty stderr**, and all four sites reported stderr alone. Every failure therefore logged as `exited with code 1: ` — the one line that explained it was read and thrown away, 35 consecutive times.

Compaction degraded gracefully into truncation fallbacks, so nothing surfaced. The result: 35 raw 14400-character transcript blobs stored as summaries and dual-written into `memory_nodes`, meaning retrieval was injecting raw transcript labelled as summary.

`--bare` is replaced with `CODEMEMORY_CHILD`, set on the spawned environment and checked by all six hook scripts, which stand down when they see it. Recursion stays prevented; authentication works.

`--no-session-persistence` is now passed too. Without it the child writes a transcript into `~/.claude/projects/`, which our own JSONL watcher then ingests as if it were the user's conversation — something `--bare` never prevented either.

## 3. Spawning a daemon is not the same as having one

`session-start.sh` spawned the daemon and immediately reported `CodeMemory initialized. Conversation will be automatically saved`, without checking whether the process survived. On a real install that message was emitted over **86 consecutive dead spawns**.

It now polls for the lookup socket — the only honest readiness signal — and abandons the wait the moment the process disappears, so a crash-on-start is detected in roughly 200 ms rather than costing the full timeout. Ceiling 3 s, overridable via `CODEMEMORY_DAEMON_HEALTH_TIMEOUT`.

When the daemon is not serving, the hook says so, names `daemon.log`, and copies its tail into `session-start.log`. `continue` stays `true` either way — **a broken memory system must never block the user's session**.

The hook result is now built with `jq` rather than string-interpolated into a heredoc; the failure reason is dynamic text, and the old form would have emitted invalid JSON on the first quote or newline.

## 4. Condensation announced success before doing the work

`runCondensation` logged `condensing N leaves into M condensed summary/ies` *before* the loop, then skipped every batch below `minFanout`. On a real database that read as 62 leaves being condensed while `summary_parents` stayed empty and the DAG stayed flat.

The log now runs after the loop and reports what was written. When every batch is skipped it warns with the numbers that explain it — leaf size, input window, leaves per batch — because that state repeats on every pass until a knob changes.

A construction-time check covers the configuration that makes condensation structurally impossible: the input window and leaf size target are separate knobs that must satisfy `minFanout × leafTargetTokens ≤ min(condensedTargetTokens × 4, compactionMaxInputChars ÷ 4)`, and nothing enforced it. Defaults satisfy it (4 × 1200 = 4800 ≤ 6000), so it stays quiet unless the relationship is actually broken.

This is why the root cause hid so long: leaves were pinned at the 3600-token truncation cap rather than the 1200-token target, because of §2. Two leaves then exceeded the 6000-token window, so each batch held one leaf and all were discarded.

## 5. Restore the prior foreign key setting after the `memory_nodes` rebuild

`ensureMemoryNodeKindSupport` disables foreign key enforcement while it drops and renames `memory_nodes`, but its `finally` turned it back **ON** unconditionally. That branch only runs for pre-`task`/`constraint` databases, so one connection behaved two ways depending on how old the file on disk was. The pragma is now read up front and restored to what was actually there.

---

## Verification

- **290/290 tests pass** (4 new, covering both halves of §4)
- Smoke-tested **against the compiled output, not `src`**: with no `sqlite` package present in `node_modules` at all, `dist/hooks/daemon.js` starts, migrates, and opens its socket
- Live daemon, 890 messages, one compaction run:

| | before | after |
|---|---|---|
| `claude --print` | 100% fail (`Not logged in`) | succeeds |
| summary size | every one pinned at 3600 tokens (truncation cap) | 173–539 tokens, real summaries |
| truncation fallbacks logged | 35 | **0** |

- Guard verified by process count: `CODEMEMORY_CHILD=1 claude --print …` spawns no new daemon (2 → 2). All six hooks return a noop under it.
- Health check exercised both ways with a stubbed plugin root: a daemon exiting non-zero produces the warning within the same second; a real start reports healthy with the socket confirmed on disk.
- Foreign key restore verified against a hand-built legacy database: schema upgrades, rows preserved, `foreign_keys` left at `0` matching a fresh database. The suite never covered that path because every test starts from an empty file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)