### PR TITLE
fix: CLI subprocesses cannot authenticate, and condensation reports success while doing nothing

### DIFF
--- a/dist/compaction/compactor.js
+++ b/dist/compaction/compactor.js
@@ -18,6 +18,7 @@
  * in summary_messages. No extra column needed.
  */
 import { spawn } from "node:child_process";
+import { buildClaudeCliArgs, claudeCliSpawnEnv, describeClaudeCliFailure, } from "../llm/claude-cli.js";
 import { createMemoryNodeStore } from "../store/memory-store.js";
 /**
  * Marker prepended to fallback "summaries" so readers see immediately that
@@ -395,14 +396,7 @@ export class AsyncCompactor {
     async callLlmOrTruncate(prompt, fallbackContent, options) {
         if (!this.config.compactionDisableLlm) {
             try {
-                // `--bare` skips hooks / plugin sync / CLAUDE.md discovery — critical
-                // when this spawn runs from inside the daemon (or any Claude-invoked
-                // process), otherwise the child reloads our own SessionStart hook
-                // chain and restarts another daemon.
-                const args = ["--bare", "--print", "--output-format", "text"];
-                if (this.config.compactionModel) {
-                    args.push("--model", this.config.compactionModel);
-                }
+                const args = buildClaudeCliArgs(this.config.compactionModel);
                 const raw = await spawnWithStdin("claude", args, prompt, 30_000);
                 const firstParsed = parseSummaryWithMetadata(raw);
                 const firstCheck = this.validateSummaryQuality(firstParsed.content, fallbackContent, options);
@@ -500,7 +494,10 @@ function normalizeForOverlap(text) {
  */
 function spawnWithStdin(cmd, args, input, timeoutMs) {
     return new Promise((resolve, reject) => {
-        const child = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"] });
+        const child = spawn(cmd, args, {
+            stdio: ["pipe", "pipe", "pipe"],
+            env: claudeCliSpawnEnv(),
+        });
         const stdoutChunks = [];
         const stderrChunks = [];
         let settled = false;
@@ -526,8 +523,8 @@ function spawnWithStdin(cmd, args, input, timeoutMs) {
             settled = true;
             clearTimeout(timer);
             if (code !== 0) {
-                const stderr = Buffer.concat(stderrChunks).toString("utf-8").slice(0, 500);
-                reject(new Error(`claude --print exited with code ${code}: ${stderr}`));
+                const reason = describeClaudeCliFailure(Buffer.concat(stdoutChunks).toString("utf-8"), Buffer.concat(stderrChunks).toString("utf-8"));
+                reject(new Error(`claude --print exited with code ${code}: ${reason}`));
                 return;
             }
             resolve(Buffer.concat(stdoutChunks).toString("utf-8").trim());

--- a/dist/compaction/compactor.js
+++ b/dist/compaction/compactor.js
@@ -104,6 +104,38 @@ export class AsyncCompactor {
         this.db = db;
         this.config = config;
         this.logger = logger;
+        this.warnIfCondensationUnreachable();
+    }
+    /**
+     * The condensation input window and the leaf size target are set by separate
+     * knobs that must satisfy `minFanout × leafTargetTokens <= maxInputTokens` for
+     * a batch to ever reach the fanout threshold. Nothing enforced that, so a
+     * config where the DAG can never grow a level looked exactly like a config
+     * where it simply had not grown yet. Check it once, at construction.
+     */
+    warnIfCondensationUnreachable() {
+        if ((this.config.incrementalMaxDepth ?? 1) < 1)
+            return;
+        const minFanout = this.config.condensedMinFanout ?? 4;
+        const leafTokens = this.config.leafTargetTokens;
+        const maxInputTokens = this.condensationInputWindowTokens();
+        const required = minFanout * leafTokens;
+        if (required <= maxInputTokens)
+            return;
+        this.logger.warn(`[compactor] condensation can never trigger with this configuration: ` +
+            `minFanout ${minFanout} × leafTargetTokens ${leafTokens} = ${required} tokens ` +
+            `exceeds the ${maxInputTokens}-token condensation input window ` +
+            `(min(condensedTargetTokens ${this.config.condensedTargetTokens} × 4, ` +
+            `compactionMaxInputChars ${this.config.compactionMaxInputChars} ÷ 4)). ` +
+            `Every batch will fall below minFanout and the summary DAG will stay flat.`);
+    }
+    /**
+     * condensedTargetTokens is the TARGET size of the produced summary; × 4 also
+     * serves as the input window so a batch stays summarizable in one LLM call.
+     */
+    condensationInputWindowTokens() {
+        const targetTokens = this.config.condensedTargetTokens ?? 2000;
+        return Math.min(targetTokens * 4, Math.floor(this.config.compactionMaxInputChars / 4));
     }
     /**
      * Called after every insertMessage. Non-blocking: schedules a background
@@ -219,25 +251,53 @@ export class AsyncCompactor {
             this.logger.debug(`[compactor] condensation skipped: ${orphans.length} un-parented leaves < minFanout ${minFanout}`);
             return [];
         }
-        // Batch orphan leaves by token budget so each condensed row stays
-        // within a sane size. condensedTargetTokens is the TARGET size of the
-        // produced summary, but we also use it (× 4 chars/token) as the input
-        // window so each batch can be realistically summarized in one LLM call.
-        const targetTokens = this.config.condensedTargetTokens ?? 2000;
-        const maxInputTokens = Math.min(targetTokens * 4, Math.floor(this.config.compactionMaxInputChars / 4));
+        // Batch orphan leaves by token budget so each condensed row stays within a
+        // sane size.
+        const maxInputTokens = this.condensationInputWindowTokens();
         const batches = this.batchLeavesByTokens(orphans, maxInputTokens);
-        this.logger.info(`[compactor] condensing ${orphans.length} leaves into ${batches.length} condensed summary/ies`);
         const createdIds = [];
+        let skippedBatches = 0;
         for (const batch of batches) {
             if (batch.length < minFanout && batches.length > 1) {
                 // A trailing sub-fanout batch (e.g. 7 leaves / minFanout 4 → [4,3]):
                 // leave the stragglers un-parented so they can join the next pass.
+                skippedBatches++;
                 continue;
             }
             const id = await this.condenseBatch(conversationId, batch);
             createdIds.push(id);
         }
+        // Report what happened, not what was attempted. This used to log
+        // "condensing N leaves into M condensed summary/ies" *before* the loop, so
+        // a pass that skipped every batch still read as a success — the DAG stayed
+        // flat for months while the log claimed otherwise.
+        if (createdIds.length > 0) {
+            this.logger.info(`[compactor] condensed ${orphans.length - skippedBatches * minFanout} of ${orphans.length} un-parented leaves into ${createdIds.length} summary/ies (${skippedBatches} batch(es) left for the next pass)`);
+        }
+        else {
+            this.warnCondensationStarved(orphans, batches.length, maxInputTokens, minFanout);
+        }
         return createdIds;
+    }
+    /**
+     * Every batch fell below minFanout, so condensation ran and produced nothing.
+     * That happens when leaves are large relative to the condensation input
+     * window: at `maxInputTokens` 6000 with 3600-token leaves, each batch holds a
+     * single leaf and the sub-fanout guard then discards all of them. The DAG can
+     * never grow a level in that state, so say so with the numbers needed to fix
+     * it rather than failing silently.
+     */
+    warnCondensationStarved(orphans, batchCount, maxInputTokens, minFanout) {
+        const totalTokens = orphans.reduce((sum, l) => sum + (l.tokenCount ?? 0), 0);
+        const avgLeafTokens = Math.round(totalTokens / Math.max(orphans.length, 1));
+        const leavesPerBatch = Math.floor(maxInputTokens / Math.max(avgLeafTokens, 1));
+        this.logger.warn(`[compactor] condensation produced nothing: ${orphans.length} un-parented leaves ` +
+            `formed ${batchCount} batch(es), all below minFanout ${minFanout}. ` +
+            `Leaves average ${avgLeafTokens} tokens against a ${maxInputTokens}-token input window, ` +
+            `so a batch holds about ${leavesPerBatch}. ` +
+            `Raise CODEMEMORY_CONDENSED_TARGET_TOKENS or CODEMEMORY_COMPACTION_MAX_INPUT_CHARS, ` +
+            `lower CODEMEMORY_CONDENSED_MIN_FANOUT, or find out why leaves are oversized ` +
+            `(truncation fallbacks are pinned at the fallback cap, not leafTargetTokens).`);
     }
     batchLeavesByTokens(leaves, maxTokens) {
         const batches = [];

--- a/dist/llm/claude-cli.js
+++ b/dist/llm/claude-cli.js
@@ -1,0 +1,60 @@
+/**
+ * CodeMemory for Claude Code - Shared `claude` CLI subprocess construction
+ *
+ * Four features shell out to the CLI: compaction summaries, the query planner,
+ * the decision supersede judge, and expansion delegation. They must agree on
+ * how the child is invoked, because getting it wrong disables the feature
+ * silently rather than loudly.
+ *
+ * All four used to pass `--bare`. The intent was sound — `--bare` skips hooks,
+ * and a child that replays our own SessionStart hook starts a second daemon
+ * against the same database. But `--bare` also stops the CLI reading the
+ * keychain, and documents that Anthropic auth is then *strictly*
+ * ANTHROPIC_API_KEY or an apiKeyHelper. Anyone signed in through OAuth — every
+ * subscription user — got `Not logged in · Please run /login` and exit code 1
+ * on every call. Every LLM-backed feature in the system was dead, and because
+ * each one has a graceful fallback, nothing ever surfaced it.
+ *
+ * Recursion is now prevented by `CODEMEMORY_CHILD` instead, which every hook
+ * script checks and exits on.
+ */
+/**
+ * Set on spawned children so CodeMemory's own hooks stand down. Without it a
+ * child session replays SessionStart and starts a competing daemon.
+ */
+export const CODEMEMORY_CHILD_ENV = "CODEMEMORY_CHILD";
+/**
+ * `--no-session-persistence` is not a performance tweak: without it the child
+ * writes a transcript into `~/.claude/projects/<project>/`, which our own
+ * JSONL watcher then ingests as if it were the user's conversation.
+ */
+export function buildClaudeCliArgs(model) {
+    const args = [
+        "--print",
+        "--output-format",
+        "text",
+        "--no-session-persistence",
+    ];
+    if (model) {
+        args.push("--model", model);
+    }
+    return args;
+}
+export function claudeCliSpawnEnv(base = process.env) {
+    return { ...base, [CODEMEMORY_CHILD_ENV]: "1" };
+}
+/**
+ * The CLI reports refusals to start — an expired login above all — on stdout
+ * with an empty stderr. Reporting stderr alone turned every such failure into
+ * `exited with code 1: ` and threw the one useful line away.
+ */
+export function describeClaudeCliFailure(stdout, stderr, limit = 500) {
+    const err = stderr.trim();
+    if (err)
+        return err.slice(0, limit);
+    const out = stdout.trim();
+    if (out)
+        return out.slice(0, limit);
+    return "(no output on stdout or stderr)";
+}
+//# sourceMappingURL=claude-cli.js.map

--- a/dist/query-planner.js
+++ b/dist/query-planner.js
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { buildClaudeCliArgs, claudeCliSpawnEnv, describeClaudeCliFailure, } from "./llm/claude-cli.js";
 import { createFastRetrievalPlan, normalizeTagValue, } from "./retrieval-plan.js";
 export class SmartQueryPlanner {
     config;
@@ -212,11 +213,11 @@ function clampNumber(value, fallback, min, max) {
 }
 function runClaudePlanner(prompt, config) {
     return new Promise((resolve, reject) => {
-        const args = ["--bare", "--print", "--output-format", "text"];
-        if (config.queryPlannerModel) {
-            args.push("--model", config.queryPlannerModel);
-        }
-        const child = spawn("claude", args, { stdio: ["pipe", "pipe", "pipe"] });
+        const args = buildClaudeCliArgs(config.queryPlannerModel);
+        const child = spawn("claude", args, {
+            stdio: ["pipe", "pipe", "pipe"],
+            env: claudeCliSpawnEnv(),
+        });
         const stdoutChunks = [];
         const stderrChunks = [];
         let settled = false;
@@ -242,8 +243,8 @@ function runClaudePlanner(prompt, config) {
             settled = true;
             clearTimeout(timer);
             if (code !== 0) {
-                const stderr = Buffer.concat(stderrChunks).toString("utf-8").slice(0, 500);
-                reject(new Error(`query planner exited with code ${code}: ${stderr}`));
+                const reason = describeClaudeCliFailure(Buffer.concat(stdoutChunks).toString("utf-8"), Buffer.concat(stderrChunks).toString("utf-8"));
+                reject(new Error(`query planner exited with code ${code}: ${reason}`));
                 return;
             }
             resolve(Buffer.concat(stdoutChunks).toString("utf-8").trim());

--- a/dist/store/decision-supersede-judge.js
+++ b/dist/store/decision-supersede-judge.js
@@ -12,6 +12,7 @@
  * are never auto-handled — that is a deliberate design choice.
  */
 import { spawn } from "node:child_process";
+import { buildClaudeCliArgs, claudeCliSpawnEnv, describeClaudeCliFailure, } from "../llm/claude-cli.js";
 export class ClaudeDecisionSupersedeJudge {
     config;
     runCompletion;
@@ -99,10 +100,11 @@ function truncate(s, max) {
 }
 function runClaudeJudge(prompt, config) {
     return new Promise((resolve, reject) => {
-        const args = ["--bare", "--print", "--output-format", "text"];
-        if (config.model)
-            args.push("--model", config.model);
-        const child = spawn("claude", args, { stdio: ["pipe", "pipe", "pipe"] });
+        const args = buildClaudeCliArgs(config.model);
+        const child = spawn("claude", args, {
+            stdio: ["pipe", "pipe", "pipe"],
+            env: claudeCliSpawnEnv(),
+        });
         const stdoutChunks = [];
         const stderrChunks = [];
         let settled = false;
@@ -128,8 +130,8 @@ function runClaudeJudge(prompt, config) {
             settled = true;
             clearTimeout(timer);
             if (code !== 0) {
-                const stderr = Buffer.concat(stderrChunks).toString("utf-8").slice(0, 500);
-                reject(new Error(`decision judge exited ${code}: ${stderr}`));
+                const reason = describeClaudeCliFailure(Buffer.concat(stdoutChunks).toString("utf-8"), Buffer.concat(stderrChunks).toString("utf-8"));
+                reject(new Error(`decision judge exited ${code}: ${reason}`));
                 return;
             }
             resolve(Buffer.concat(stdoutChunks).toString("utf-8").trim());

--- a/dist/tools/codememory-expand-tool.delegation.js
+++ b/dist/tools/codememory-expand-tool.delegation.js
@@ -6,6 +6,7 @@
  * existing Claude Code authentication — no separate API key needed.
  */
 import { spawn } from "node:child_process";
+import { buildClaudeCliArgs, claudeCliSpawnEnv, describeClaudeCliFailure, } from "../llm/claude-cli.js";
 const SUBAGENT_SYSTEM_PROMPT = "You are a memory-expansion subagent for the CodeMemory plugin. " +
     "Answer the user's question using only the provided conversation history excerpts. " +
     "Be concise and factual. If the excerpts don't contain enough information, say so explicitly.";
@@ -46,22 +47,19 @@ export function createExpansionDelegation(deps) {
  */
 function spawnClaudePrint(prompt, systemPrompt, timeoutMs, model) {
     return new Promise((resolve, reject) => {
-        // `--bare` keeps the subagent isolated from the parent session: it
-        // skips our own SessionStart/PreToolUse/etc hooks and plugin sync, so
+        // CODEMEMORY_CHILD (set by claudeCliSpawnEnv) keeps the subagent isolated
+        // from the parent session: our hook scripts stand down when they see it, so
         // the child won't start another CodeMemory daemon against the same sqlite
-        // file. Without this, expansion delegation was silently reentrant.
+        // file. Without that guard, expansion delegation was silently reentrant.
         const args = [
-            "--bare",
-            "--print",
-            "--output-format",
-            "text",
+            ...buildClaudeCliArgs(model),
             "--append-system-prompt",
             systemPrompt,
         ];
-        if (model) {
-            args.push("--model", model);
-        }
-        const child = spawn("claude", args, { stdio: ["pipe", "pipe", "pipe"] });
+        const child = spawn("claude", args, {
+            stdio: ["pipe", "pipe", "pipe"],
+            env: claudeCliSpawnEnv(),
+        });
         const stdoutChunks = [];
         const stderrChunks = [];
         let settled = false;
@@ -87,8 +85,8 @@ function spawnClaudePrint(prompt, systemPrompt, timeoutMs, model) {
             settled = true;
             clearTimeout(timer);
             if (code !== 0) {
-                const stderr = Buffer.concat(stderrChunks).toString("utf-8").slice(0, 500);
-                reject(new Error(`claude --print exited with code ${code}: ${stderr}`));
+                const reason = describeClaudeCliFailure(Buffer.concat(stdoutChunks).toString("utf-8"), Buffer.concat(stderrChunks).toString("utf-8"));
+                reject(new Error(`claude --print exited with code ${code}: ${reason}`));
                 return;
             }
             resolve(Buffer.concat(stdoutChunks).toString("utf-8").trim());

--- a/hooks/scripts/final-compact.sh
+++ b/hooks/scripts/final-compact.sh
@@ -7,6 +7,13 @@
 
 set -euo pipefail
 
+# Stand down inside a `claude --print` child spawned by CodeMemory itself;
+# see the note in session-start.sh.
+if [ -n "${CODEMEMORY_CHILD:-}" ]; then
+  printf '%s\n' '{"continue":true,"suppressOutput":true}'
+  exit 0
+fi
+
 SESSION_ID="${1:-unknown}"
 
 LOG_DIR="${HOME}/.claude/codememory-logs"

--- a/hooks/scripts/pre-compact.sh
+++ b/hooks/scripts/pre-compact.sh
@@ -11,6 +11,13 @@
 
 set -euo pipefail
 
+# Stand down inside a `claude --print` child spawned by CodeMemory itself;
+# see the note in session-start.sh.
+if [ -n "${CODEMEMORY_CHILD:-}" ]; then
+  printf '%s\n' '{"continue":true,"suppressOutput":true}'
+  exit 0
+fi
+
 LOG_DIR="${HOME}/.claude/codememory-logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="${LOG_DIR}/pre-compact.log"

--- a/hooks/scripts/pre-tool-use.sh
+++ b/hooks/scripts/pre-tool-use.sh
@@ -22,6 +22,13 @@ emit_noop() {
 }
 trap 'emit_noop' ERR
 
+# Stand down inside a `claude --print` child spawned by CodeMemory itself;
+# see the note in session-start.sh.
+if [ -n "${CODEMEMORY_CHILD:-}" ]; then
+  emit_noop
+  exit 0
+fi
+
 INPUT=$(cat)
 SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"')
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""')

--- a/hooks/scripts/session-end.sh
+++ b/hooks/scripts/session-end.sh
@@ -4,6 +4,14 @@
 
 set -euo pipefail
 
+# Stand down inside a `claude --print` child spawned by CodeMemory itself;
+# see the note in session-start.sh. Without this the child's SessionEnd would
+# tear down the parent session's daemon.
+if [ -n "${CODEMEMORY_CHILD:-}" ]; then
+  printf '%s\n' '{"continue":true,"suppressOutput":true}'
+  exit 0
+fi
+
 # Get hook input from stdin
 INPUT=$(cat)
 

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -4,6 +4,17 @@
 
 set -euo pipefail
 
+# CodeMemory spawns `claude --print` for summaries, query planning, the
+# supersede judge and expansion delegation. Those children run our hooks too,
+# and an unguarded SessionStart would start a second daemon against the same
+# database. This used to be prevented with `--bare`, which also stopped the CLI
+# reading the keychain and broke every LLM call for OAuth users; the parent now
+# sets CODEMEMORY_CHILD instead and every hook stands down when it sees it.
+if [ -n "${CODEMEMORY_CHILD:-}" ]; then
+    printf '%s\n' '{"continue":true,"suppressOutput":true}'
+    exit 0
+fi
+
 # Log directory
 LOG_DIR="${HOME}/.claude/codememory-logs"
 mkdir -p "$LOG_DIR"

--- a/hooks/scripts/user-prompt-submit.sh
+++ b/hooks/scripts/user-prompt-submit.sh
@@ -13,6 +13,13 @@
 
 set -euo pipefail
 
+# Stand down inside a `claude --print` child spawned by CodeMemory itself;
+# see the note in session-start.sh.
+if [ -n "${CODEMEMORY_CHILD:-}" ]; then
+  printf '%s\n' '{"continue":true,"suppressOutput":true}'
+  exit 0
+fi
+
 LOG_DIR="${HOME}/.claude/codememory-logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="${LOG_DIR}/user-prompt-submit.log"

--- a/src/compaction/compactor.ts
+++ b/src/compaction/compactor.ts
@@ -163,7 +163,47 @@ export class AsyncCompactor {
     private readonly db: any,
     private readonly config: CodeMemoryConfig,
     private readonly logger: SimpleLogger
-  ) {}
+  ) {
+    this.warnIfCondensationUnreachable();
+  }
+
+  /**
+   * The condensation input window and the leaf size target are set by separate
+   * knobs that must satisfy `minFanout × leafTargetTokens <= maxInputTokens` for
+   * a batch to ever reach the fanout threshold. Nothing enforced that, so a
+   * config where the DAG can never grow a level looked exactly like a config
+   * where it simply had not grown yet. Check it once, at construction.
+   */
+  private warnIfCondensationUnreachable(): void {
+    if ((this.config.incrementalMaxDepth ?? 1) < 1) return;
+
+    const minFanout = this.config.condensedMinFanout ?? 4;
+    const leafTokens = this.config.leafTargetTokens;
+    const maxInputTokens = this.condensationInputWindowTokens();
+    const required = minFanout * leafTokens;
+    if (required <= maxInputTokens) return;
+
+    this.logger.warn(
+      `[compactor] condensation can never trigger with this configuration: ` +
+        `minFanout ${minFanout} × leafTargetTokens ${leafTokens} = ${required} tokens ` +
+        `exceeds the ${maxInputTokens}-token condensation input window ` +
+        `(min(condensedTargetTokens ${this.config.condensedTargetTokens} × 4, ` +
+        `compactionMaxInputChars ${this.config.compactionMaxInputChars} ÷ 4)). ` +
+        `Every batch will fall below minFanout and the summary DAG will stay flat.`
+    );
+  }
+
+  /**
+   * condensedTargetTokens is the TARGET size of the produced summary; × 4 also
+   * serves as the input window so a batch stays summarizable in one LLM call.
+   */
+  private condensationInputWindowTokens(): number {
+    const targetTokens = this.config.condensedTargetTokens ?? 2000;
+    return Math.min(
+      targetTokens * 4,
+      Math.floor(this.config.compactionMaxInputChars / 4)
+    );
+  }
 
   /**
    * Called after every insertMessage. Non-blocking: schedules a background
@@ -311,32 +351,66 @@ export class AsyncCompactor {
       return [];
     }
 
-    // Batch orphan leaves by token budget so each condensed row stays
-    // within a sane size. condensedTargetTokens is the TARGET size of the
-    // produced summary, but we also use it (× 4 chars/token) as the input
-    // window so each batch can be realistically summarized in one LLM call.
-    const targetTokens = this.config.condensedTargetTokens ?? 2000;
-    const maxInputTokens = Math.min(
-      targetTokens * 4,
-      Math.floor(this.config.compactionMaxInputChars / 4)
-    );
+    // Batch orphan leaves by token budget so each condensed row stays within a
+    // sane size.
+    const maxInputTokens = this.condensationInputWindowTokens();
     const batches = this.batchLeavesByTokens(orphans, maxInputTokens);
 
-    this.logger.info(
-      `[compactor] condensing ${orphans.length} leaves into ${batches.length} condensed summary/ies`
-    );
-
     const createdIds: string[] = [];
+    let skippedBatches = 0;
     for (const batch of batches) {
       if (batch.length < minFanout && batches.length > 1) {
         // A trailing sub-fanout batch (e.g. 7 leaves / minFanout 4 → [4,3]):
         // leave the stragglers un-parented so they can join the next pass.
+        skippedBatches++;
         continue;
       }
       const id = await this.condenseBatch(conversationId, batch);
       createdIds.push(id);
     }
+
+    // Report what happened, not what was attempted. This used to log
+    // "condensing N leaves into M condensed summary/ies" *before* the loop, so
+    // a pass that skipped every batch still read as a success — the DAG stayed
+    // flat for months while the log claimed otherwise.
+    if (createdIds.length > 0) {
+      this.logger.info(
+        `[compactor] condensed ${orphans.length - skippedBatches * minFanout} of ${orphans.length} un-parented leaves into ${createdIds.length} summary/ies (${skippedBatches} batch(es) left for the next pass)`
+      );
+    } else {
+      this.warnCondensationStarved(orphans, batches.length, maxInputTokens, minFanout);
+    }
+
     return createdIds;
+  }
+
+  /**
+   * Every batch fell below minFanout, so condensation ran and produced nothing.
+   * That happens when leaves are large relative to the condensation input
+   * window: at `maxInputTokens` 6000 with 3600-token leaves, each batch holds a
+   * single leaf and the sub-fanout guard then discards all of them. The DAG can
+   * never grow a level in that state, so say so with the numbers needed to fix
+   * it rather than failing silently.
+   */
+  private warnCondensationStarved(
+    orphans: LeafSummaryRow[],
+    batchCount: number,
+    maxInputTokens: number,
+    minFanout: number
+  ): void {
+    const totalTokens = orphans.reduce((sum, l) => sum + (l.tokenCount ?? 0), 0);
+    const avgLeafTokens = Math.round(totalTokens / Math.max(orphans.length, 1));
+    const leavesPerBatch = Math.floor(maxInputTokens / Math.max(avgLeafTokens, 1));
+
+    this.logger.warn(
+      `[compactor] condensation produced nothing: ${orphans.length} un-parented leaves ` +
+        `formed ${batchCount} batch(es), all below minFanout ${minFanout}. ` +
+        `Leaves average ${avgLeafTokens} tokens against a ${maxInputTokens}-token input window, ` +
+        `so a batch holds about ${leavesPerBatch}. ` +
+        `Raise CODEMEMORY_CONDENSED_TARGET_TOKENS or CODEMEMORY_COMPACTION_MAX_INPUT_CHARS, ` +
+        `lower CODEMEMORY_CONDENSED_MIN_FANOUT, or find out why leaves are oversized ` +
+        `(truncation fallbacks are pinned at the fallback cap, not leafTargetTokens).`
+    );
   }
 
   private batchLeavesByTokens(leaves: LeafSummaryRow[], maxTokens: number): LeafSummaryRow[][] {

--- a/src/compaction/compactor.ts
+++ b/src/compaction/compactor.ts
@@ -19,6 +19,11 @@
  */
 
 import { spawn } from "node:child_process";
+import {
+  buildClaudeCliArgs,
+  claudeCliSpawnEnv,
+  describeClaudeCliFailure,
+} from "../llm/claude-cli.js";
 import type { CodeMemoryConfig } from "../db/config.js";
 import { createMemoryNodeStore } from "../store/memory-store.js";
 
@@ -566,14 +571,7 @@ export class AsyncCompactor {
   ): Promise<{ content: string; metadata: SummaryMetadata | null }> {
     if (!this.config.compactionDisableLlm) {
       try {
-        // `--bare` skips hooks / plugin sync / CLAUDE.md discovery — critical
-        // when this spawn runs from inside the daemon (or any Claude-invoked
-        // process), otherwise the child reloads our own SessionStart hook
-        // chain and restarts another daemon.
-        const args = ["--bare", "--print", "--output-format", "text"];
-        if (this.config.compactionModel) {
-          args.push("--model", this.config.compactionModel);
-        }
+        const args = buildClaudeCliArgs(this.config.compactionModel);
         const raw = await spawnWithStdin("claude", args, prompt, 30_000);
         const firstParsed = parseSummaryWithMetadata(raw);
         const firstCheck = this.validateSummaryQuality(
@@ -724,7 +722,10 @@ function spawnWithStdin(
   timeoutMs: number
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"] });
+    const child = spawn(cmd, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: claudeCliSpawnEnv(),
+    });
 
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
@@ -752,8 +753,11 @@ function spawnWithStdin(
       settled = true;
       clearTimeout(timer);
       if (code !== 0) {
-        const stderr = Buffer.concat(stderrChunks).toString("utf-8").slice(0, 500);
-        reject(new Error(`claude --print exited with code ${code}: ${stderr}`));
+        const reason = describeClaudeCliFailure(
+          Buffer.concat(stdoutChunks).toString("utf-8"),
+          Buffer.concat(stderrChunks).toString("utf-8")
+        );
+        reject(new Error(`claude --print exited with code ${code}: ${reason}`));
         return;
       }
       resolve(Buffer.concat(stdoutChunks).toString("utf-8").trim());

--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -1,0 +1,69 @@
+/**
+ * CodeMemory for Claude Code - Shared `claude` CLI subprocess construction
+ *
+ * Four features shell out to the CLI: compaction summaries, the query planner,
+ * the decision supersede judge, and expansion delegation. They must agree on
+ * how the child is invoked, because getting it wrong disables the feature
+ * silently rather than loudly.
+ *
+ * All four used to pass `--bare`. The intent was sound — `--bare` skips hooks,
+ * and a child that replays our own SessionStart hook starts a second daemon
+ * against the same database. But `--bare` also stops the CLI reading the
+ * keychain, and documents that Anthropic auth is then *strictly*
+ * ANTHROPIC_API_KEY or an apiKeyHelper. Anyone signed in through OAuth — every
+ * subscription user — got `Not logged in · Please run /login` and exit code 1
+ * on every call. Every LLM-backed feature in the system was dead, and because
+ * each one has a graceful fallback, nothing ever surfaced it.
+ *
+ * Recursion is now prevented by `CODEMEMORY_CHILD` instead, which every hook
+ * script checks and exits on.
+ */
+
+/**
+ * Set on spawned children so CodeMemory's own hooks stand down. Without it a
+ * child session replays SessionStart and starts a competing daemon.
+ */
+export const CODEMEMORY_CHILD_ENV = "CODEMEMORY_CHILD";
+
+/**
+ * `--no-session-persistence` is not a performance tweak: without it the child
+ * writes a transcript into `~/.claude/projects/<project>/`, which our own
+ * JSONL watcher then ingests as if it were the user's conversation.
+ */
+export function buildClaudeCliArgs(model?: string): string[] {
+  const args = [
+    "--print",
+    "--output-format",
+    "text",
+    "--no-session-persistence",
+  ];
+  if (model) {
+    args.push("--model", model);
+  }
+  return args;
+}
+
+export function claudeCliSpawnEnv(
+  base: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  return { ...base, [CODEMEMORY_CHILD_ENV]: "1" };
+}
+
+/**
+ * The CLI reports refusals to start — an expired login above all — on stdout
+ * with an empty stderr. Reporting stderr alone turned every such failure into
+ * `exited with code 1: ` and threw the one useful line away.
+ */
+export function describeClaudeCliFailure(
+  stdout: string,
+  stderr: string,
+  limit = 500
+): string {
+  const err = stderr.trim();
+  if (err) return err.slice(0, limit);
+
+  const out = stdout.trim();
+  if (out) return out.slice(0, limit);
+
+  return "(no output on stdout or stderr)";
+}

--- a/src/query-planner.ts
+++ b/src/query-planner.ts
@@ -1,4 +1,9 @@
 import { spawn } from "node:child_process";
+import {
+  buildClaudeCliArgs,
+  claudeCliSpawnEnv,
+  describeClaudeCliFailure,
+} from "./llm/claude-cli.js";
 import type { CodeMemoryConfig } from "./db/config.js";
 import {
   createFastRetrievalPlan,
@@ -279,12 +284,12 @@ function runClaudePlanner(
   config: Pick<CodeMemoryConfig, "queryPlannerModel" | "queryPlannerTimeoutMs">
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    const args = ["--bare", "--print", "--output-format", "text"];
-    if (config.queryPlannerModel) {
-      args.push("--model", config.queryPlannerModel);
-    }
+    const args = buildClaudeCliArgs(config.queryPlannerModel);
 
-    const child = spawn("claude", args, { stdio: ["pipe", "pipe", "pipe"] });
+    const child = spawn("claude", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: claudeCliSpawnEnv(),
+    });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     let settled = false;
@@ -309,8 +314,11 @@ function runClaudePlanner(
       settled = true;
       clearTimeout(timer);
       if (code !== 0) {
-        const stderr = Buffer.concat(stderrChunks).toString("utf-8").slice(0, 500);
-        reject(new Error(`query planner exited with code ${code}: ${stderr}`));
+        const reason = describeClaudeCliFailure(
+          Buffer.concat(stdoutChunks).toString("utf-8"),
+          Buffer.concat(stderrChunks).toString("utf-8")
+        );
+        reject(new Error(`query planner exited with code ${code}: ${reason}`));
         return;
       }
       resolve(Buffer.concat(stdoutChunks).toString("utf-8").trim());

--- a/src/store/decision-supersede-judge.ts
+++ b/src/store/decision-supersede-judge.ts
@@ -12,6 +12,11 @@
  * are never auto-handled — that is a deliberate design choice.
  */
 import { spawn } from "node:child_process";
+import {
+  buildClaudeCliArgs,
+  claudeCliSpawnEnv,
+  describeClaudeCliFailure,
+} from "../llm/claude-cli.js";
 
 export interface DecisionJudgeCandidate {
   nodeId: string;
@@ -135,9 +140,11 @@ function runClaudeJudge(
   config: DecisionJudgeConfig
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    const args = ["--bare", "--print", "--output-format", "text"];
-    if (config.model) args.push("--model", config.model);
-    const child = spawn("claude", args, { stdio: ["pipe", "pipe", "pipe"] });
+    const args = buildClaudeCliArgs(config.model);
+    const child = spawn("claude", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: claudeCliSpawnEnv(),
+    });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     let settled = false;
@@ -160,8 +167,11 @@ function runClaudeJudge(
       settled = true;
       clearTimeout(timer);
       if (code !== 0) {
-        const stderr = Buffer.concat(stderrChunks).toString("utf-8").slice(0, 500);
-        reject(new Error(`decision judge exited ${code}: ${stderr}`));
+        const reason = describeClaudeCliFailure(
+          Buffer.concat(stdoutChunks).toString("utf-8"),
+          Buffer.concat(stderrChunks).toString("utf-8")
+        );
+        reject(new Error(`decision judge exited ${code}: ${reason}`));
         return;
       }
       resolve(Buffer.concat(stdoutChunks).toString("utf-8").trim());

--- a/src/tools/codememory-expand-tool.delegation.ts
+++ b/src/tools/codememory-expand-tool.delegation.ts
@@ -7,6 +7,11 @@
  */
 
 import { spawn } from "node:child_process";
+import {
+  buildClaudeCliArgs,
+  claudeCliSpawnEnv,
+  describeClaudeCliFailure,
+} from "../llm/claude-cli.js";
 import type { CodeMemoryDependencies } from "../types.js";
 
 export interface DelegationParams {
@@ -79,22 +84,19 @@ function spawnClaudePrint(
   model?: string
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    // `--bare` keeps the subagent isolated from the parent session: it
-    // skips our own SessionStart/PreToolUse/etc hooks and plugin sync, so
+    // CODEMEMORY_CHILD (set by claudeCliSpawnEnv) keeps the subagent isolated
+    // from the parent session: our hook scripts stand down when they see it, so
     // the child won't start another CodeMemory daemon against the same sqlite
-    // file. Without this, expansion delegation was silently reentrant.
+    // file. Without that guard, expansion delegation was silently reentrant.
     const args = [
-      "--bare",
-      "--print",
-      "--output-format",
-      "text",
+      ...buildClaudeCliArgs(model),
       "--append-system-prompt",
       systemPrompt,
     ];
-    if (model) {
-      args.push("--model", model);
-    }
-    const child = spawn("claude", args, { stdio: ["pipe", "pipe", "pipe"] });
+    const child = spawn("claude", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: claudeCliSpawnEnv(),
+    });
 
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
@@ -122,8 +124,11 @@ function spawnClaudePrint(
       settled = true;
       clearTimeout(timer);
       if (code !== 0) {
-        const stderr = Buffer.concat(stderrChunks).toString("utf-8").slice(0, 500);
-        reject(new Error(`claude --print exited with code ${code}: ${stderr}`));
+        const reason = describeClaudeCliFailure(
+          Buffer.concat(stdoutChunks).toString("utf-8"),
+          Buffer.concat(stderrChunks).toString("utf-8")
+        );
+        reject(new Error(`claude --print exited with code ${code}: ${reason}`));
         return;
       }
       resolve(Buffer.concat(stdoutChunks).toString("utf-8").trim());

--- a/test/condensation.test.ts
+++ b/test/condensation.test.ts
@@ -23,7 +23,7 @@ import { createCodeMemoryDatabaseConnection } from "../src/db/connection.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
 import { CodeMemoryContextEngine } from "../src/engine.js";
 import { resolveCodeMemoryConfig } from "../src/db/config.js";
-import { TRUNCATION_FALLBACK_MARKER } from "../src/compaction/compactor.js";
+import { AsyncCompactor, TRUNCATION_FALLBACK_MARKER } from "../src/compaction/compactor.js";
 
 let dbDir: string;
 const savedEnv: Record<string, string | undefined> = {};
@@ -39,6 +39,9 @@ const TRACKED_ENV = [
   "CODEMEMORY_LEAF_CHUNK_TOKENS",
   "CODEMEMORY_CONDENSED_MIN_FANOUT",
   "CODEMEMORY_COMPACTION_FRESH_TAIL_COUNT",
+  "CODEMEMORY_LEAF_TARGET_TOKENS",
+  "CODEMEMORY_CONDENSED_TARGET_TOKENS",
+  "CODEMEMORY_COMPACTION_MAX_INPUT_CHARS",
 ];
 
 beforeEach(() => {
@@ -207,6 +210,127 @@ describe("runCondensation (Phase 6)", () => {
         "SELECT COUNT(*) as n FROM summaries WHERE kind = 'condensed'"
       );
       expect(condCount.n).toBe(1);
+    } finally {
+      await db.close();
+    }
+  });
+});
+
+/**
+ * Condensation used to announce its intent before doing the work — "condensing
+ * N leaves into M condensed summary/ies" — and then skip every batch. A DAG
+ * that had been flat for months therefore read as healthy in the logs. These
+ * cover both halves: the log must describe the outcome, and a configuration in
+ * which condensation can never fire must say so out loud.
+ */
+describe("runCondensation diagnostics", () => {
+  function capturingLogger() {
+    const warns: string[] = [];
+    const infos: string[] = [];
+    return {
+      warns,
+      infos,
+      logger: {
+        debug: () => {},
+        info: (...args: any[]) => infos.push(args.join(" ")),
+        warn: (...args: any[]) => warns.push(args.join(" ")),
+        error: () => {},
+      },
+    };
+  }
+
+  it("warns at construction when minFanout x leafTargetTokens exceeds the input window", async () => {
+    process.env.CODEMEMORY_CONDENSED_MIN_FANOUT = "4";
+    process.env.CODEMEMORY_LEAF_TARGET_TOKENS = "3600";
+    process.env.CODEMEMORY_COMPACTION_MAX_INPUT_CHARS = "24000";
+
+    const db = await createCodeMemoryDatabaseConnection(
+      process.env.CODEMEMORY_DATABASE_PATH!
+    );
+    try {
+      const { warns, logger } = capturingLogger();
+      // 4 x 3600 = 14400 tokens needed, against a min(2000x4, 24000/4) = 6000
+      // token window. No batch can ever reach the fanout threshold.
+      new AsyncCompactor(db, resolveCodeMemoryConfig(), logger);
+
+      expect(warns.join("\n")).toContain("condensation can never trigger");
+      expect(warns.join("\n")).toContain("14400");
+      expect(warns.join("\n")).toContain("6000");
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("stays quiet at construction under the default configuration", async () => {
+    const db = await createCodeMemoryDatabaseConnection(
+      process.env.CODEMEMORY_DATABASE_PATH!
+    );
+    try {
+      const { warns, logger } = capturingLogger();
+      // Defaults: 4 x 1200 = 4800 <= 6000. Healthy, so no warning.
+      new AsyncCompactor(db, resolveCodeMemoryConfig(), logger);
+      expect(warns).toEqual([]);
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("reports what condensation actually created, not what it attempted", async () => {
+    await seedConversation("sess-outcome", 24);
+
+    const db = await createCodeMemoryDatabaseConnection(
+      process.env.CODEMEMORY_DATABASE_PATH!
+    );
+    try {
+      const { infos, logger } = capturingLogger();
+      const compactor = new AsyncCompactor(db, resolveCodeMemoryConfig(), logger);
+      const conv = await db.get(
+        "SELECT conversationId FROM conversations WHERE sessionId = ?",
+        "sess-outcome"
+      );
+      await compactor.forceCompact(conv.conversationId);
+
+      const condensed = await db.get(
+        "SELECT COUNT(*) as n FROM summaries WHERE kind = 'condensed'"
+      );
+      expect(condensed.n).toBe(1);
+
+      // The count in the log has to match what landed in the table.
+      const line = infos.find((l) => l.includes("condensed"));
+      expect(line).toBeDefined();
+      expect(line).toContain("into 1 summary/ies");
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("warns instead of failing silently when every batch falls below minFanout", async () => {
+    // A 400-token window against 50-token-per-message leaves still admits
+    // several leaves, so shrink the window until one leaf fills a batch.
+    process.env.CODEMEMORY_CONDENSED_MIN_FANOUT = "4";
+    process.env.CODEMEMORY_COMPACTION_MAX_INPUT_CHARS = "400";
+    await seedConversation("sess-starved", 24);
+
+    const db = await createCodeMemoryDatabaseConnection(
+      process.env.CODEMEMORY_DATABASE_PATH!
+    );
+    try {
+      const { warns, logger } = capturingLogger();
+      const compactor = new AsyncCompactor(db, resolveCodeMemoryConfig(), logger);
+      const conv = await db.get(
+        "SELECT conversationId FROM conversations WHERE sessionId = ?",
+        "sess-starved"
+      );
+      await compactor.forceCompact(conv.conversationId);
+
+      const condensed = await db.get(
+        "SELECT COUNT(*) as n FROM summaries WHERE kind = 'condensed'"
+      );
+      expect(condensed.n).toBe(0);
+
+      const text = warns.join("\n");
+      expect(text).toContain("condensation produced nothing");
+      expect(text).toContain("minFanout 4");
     } finally {
       await db.close();
     }


### PR DESCRIPTION
Carries the two commits that were pushed to #4's branch after it had already merged, so they never reached `main`. Nothing here is in `main` today — `src/compaction/compactor.ts` still passes `--bare` in two places.

Both problems share the shape #4 was about: **the code reports what it attempted, not what happened.**

---

## 1. Every LLM-backed feature is dead, and none of them say so

All four spawn sites — compaction summaries, the query planner, the decision supersede judge, expansion delegation — pass `--bare`. The intent was sound: `--bare` skips hooks, and a child that replays our own SessionStart starts a second daemon against the same database.

But `--bare` also stops the CLI reading the keychain, and documents that Anthropic auth is then *strictly* `ANTHROPIC_API_KEY` or an apiKeyHelper. Anyone signed in through OAuth — every subscription user — gets exit code 1 on every call:

```
$ printf 'Say OK' | claude --bare --print --output-format text
exit=1   stdout: "Not logged in · Please run /login"

$ printf 'Say OK' | claude --print --output-format text
exit=0   stdout: "OK"
```

The CLI prints that refusal **on stdout with an empty stderr**, and all four sites report stderr alone. Every failure therefore logs as `exited with code 1: ` — the one line that explains it is read and thrown away. On a real database that happened 35 consecutive times without a single legible message.

Compaction degrades gracefully into truncation fallbacks, so nothing surfaced. The result: 35 raw 14400-character transcript blobs stored as summaries and dual-written into `memory_nodes`, so retrieval was injecting raw transcript labelled as summary.

**Fix.** `--bare` is replaced with `CODEMEMORY_CHILD`, set on the spawned environment and checked by all six hook scripts, which stand down when they see it. Recursion stays prevented; authentication works. A new `src/llm/claude-cli.ts` holds the shared args, env and failure description so the four sites cannot drift apart again.

Two things fall out of the shared helper:

- **`--no-session-persistence`** is now passed. Without it the child writes a transcript into `~/.claude/projects/`, which our own JSONL watcher then ingests as if it were the user's conversation. `--bare` never prevented this either.
- **Failure reporting falls back to stdout** when stderr is empty, so a refusal to start is legible instead of blank.

## 2. Condensation announces success before doing the work

`runCondensation` logs `condensing N leaves into M condensed summary/ies` *before* the loop, then skips every batch that falls below `minFanout`. On a real database that read as 62 leaves being condensed while `summary_parents` stayed empty and the DAG stayed flat.

**Fix.** The log moves after the loop and reports what was actually written, including how many batches were deferred. When every batch is skipped it warns with the numbers that explain it — leaf size, input window, leaves per batch — because that state is not transient: it repeats on every pass until a knob changes.

A construction-time check covers the configuration that makes condensation structurally impossible. The input window and the leaf size target are separate knobs that must satisfy `minFanout × leafTargetTokens ≤ min(condensedTargetTokens × 4, compactionMaxInputChars ÷ 4)`, and nothing enforced it. Defaults satisfy it (4 × 1200 = 4800 ≤ 6000), so the check is quiet unless the relationship is actually broken.

This is why the root cause hid so long: leaves were pinned at the 3600-token truncation cap rather than the 1200-token target, because of §1. Two leaves then exceeded the 6000-token window, so each batch held one leaf and all of them were discarded.

---

## Verification

- **290/290 tests pass** — 4 new, covering both halves of §2
- `dist/` rebuilt and committed (tracked here), and `npm run build` produces no further diff
- Live daemon, 890 messages ingested, one compaction run:

| | before | after |
|---|---|---|
| `claude --print` | 100% fail (`Not logged in`) | succeeds |
| summary size | every one pinned at 3600 tokens (truncation cap) | 173–539 tokens, real summaries |
| truncation fallbacks logged | 35 | **0** |

- Recursion guard verified by process count: `CODEMEMORY_CHILD=1 claude --print …` spawns no new daemon (2 → 2). All six hook scripts return a noop under it.

The new tests are deliberately shaped around how this hid for so long — one of them asserts that the number in the log matches the number of rows actually written to `summaries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)