### PR TITLE
feat: live-only ingestion, plus an explicit re-import command

### DIFF
--- a/commands/codememory-reimport.md
+++ b/commands/codememory-reimport.md
@@ -1,0 +1,58 @@
+---
+name: codememory-reimport
+description: Rebuild a session's stored memory from its transcript on disk
+---
+
+# codememory-reimport
+
+Rebuild everything CodeMemory has stored for one session by replaying its
+transcript.
+
+## Usage
+
+```
+/codememory-reimport                 # rebuild the current session
+/codememory-reimport <session-id>    # rebuild a specific session
+```
+
+## When to use it
+
+The daemon ingests live only. Transcripts already on disk when it starts are
+treated as handled, so nothing is re-read on a restart and no rows are
+duplicated. The gap that leaves is deliberate, and this command is how it gets
+closed:
+
+- a session ran while the daemon was down or crashed
+- the stored data for a session looks wrong or incomplete
+- an older session predates a change in how messages are scored or extracted
+
+## What it does
+
+**This deletes before it rebuilds.** Everything the session owns — messages,
+message parts, summaries, memory nodes, attempt spans, explored targets — is
+removed, then reconstructed from the jsonl. That is what makes it safe to run
+twice: the result of running it repeatedly is identical to running it once.
+
+The rebuild has two phases:
+
+1. **Deterministic replay.** Every line goes back through the same ingest path
+   the live watcher uses — same scorer, same tiers, same extractors — so
+   failures, fix attempts and summaries are recovered exactly as they would
+   have been captured live.
+
+2. **Key-memory extraction.** Decisions, tasks and constraints are stated in
+   prose and no rule produces them, so an LLM pass reads them back out of the
+   transcript. Skipped when `CODEMEMORY_COMPACTION_DISABLE_LLM=true`, in which
+   case the response says so rather than silently dropping them.
+
+Phase 2 costs model calls proportional to transcript length, so a long session
+takes a while. Nothing is written until the delete and replay have succeeded.
+
+## Process
+
+1. Run `${CLAUDE_PLUGIN_ROOT}/hooks/scripts/codememory-reimport.sh` with the
+   session id, if one was given.
+2. Report the JSON it prints: rows deleted per table, lines parsed, messages
+   stored, and how many decisions / tasks / constraints were recovered.
+3. If `ok` is false, show the error and point at
+   `~/.claude/codememory-logs/reimport.log`.

--- a/dist/hooks/daemon.js
+++ b/dist/hooks/daemon.js
@@ -10,6 +10,7 @@ import * as http from "node:http";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { startProjectWatcher } from "./project-watcher-manager.js";
+import { buildExtractionTranscript, extractKeyMemories, } from "../memory/extract-key-memories.js";
 import { resolveCodeMemoryConfig } from "../db/config.js";
 import { createCodeMemoryDatabaseConnection } from "../db/connection.js";
 import { ConversationStore } from "../store/conversation-store.js";
@@ -201,6 +202,30 @@ async function startDaemon(args) {
             // SessionEnd hooks. Body is optional JSON `{sessionId?}`; defaults to
             // the daemon's own sessionId. Fire-and-forget: we 202 immediately and
             // run the work in the background so the hook never blocks the user.
+            if (req.url === "/reimport") {
+                const chunks = [];
+                req.on("data", (c) => chunks.push(c));
+                req.on("end", async () => {
+                    try {
+                        const raw = Buffer.concat(chunks).toString("utf-8").trim();
+                        const body = raw ? JSON.parse(raw) : {};
+                        const target = typeof body.sessionId === "string" && body.sessionId
+                            ? body.sessionId
+                            : sessionId;
+                        logger.info(`[reimport] rebuilding session ${target}`);
+                        const result = await reimportSession(target);
+                        logger.info(`[reimport] ${JSON.stringify(result)}`);
+                        res.writeHead(200, { "content-type": "application/json" });
+                        res.end(JSON.stringify({ ok: true, ...result }));
+                    }
+                    catch (err) {
+                        logger.error(`[reimport] failed: ${err}`);
+                        res.writeHead(500, { "content-type": "application/json" });
+                        res.end(JSON.stringify({ ok: false, error: String(err) }));
+                    }
+                });
+                return;
+            }
             if (req.url === "/compact") {
                 const chunks = [];
                 req.on("data", (c) => chunks.push(c));
@@ -390,190 +415,366 @@ async function startDaemon(args) {
             }
             return e;
         };
+        /**
+         * The one place a transcript line becomes rows. The watcher calls it
+         * live; /reimport calls it again when rebuilding a session from its
+         * jsonl, so both paths cannot drift apart.
+         */
+        const ingestOne = async (message, filePath) => {
+            // Get or create conversation for this session
+            const fileName = path.basename(filePath, ".jsonl");
+            const fileSessionId = fileName || sessionId;
+            try {
+                // Extract phase: observe every message for mutation tracking
+                // (even if it might be dropped later).
+                const extractor = getExtractor(fileSessionId);
+                const conversation = await conversationStore.getOrCreateConversation({
+                    sessionId: fileSessionId,
+                });
+                const nextSeqResult = await conversationStore.getDatabase().get(`SELECT MAX(seq) as maxSeq FROM conversation_messages WHERE conversationId = ?`, conversation.conversationId);
+                const seq = (nextSeqResult?.maxSeq ?? -1) + 1;
+                extractor.observeMessage(message, seq);
+                // Filter/Score: decide tier + final content. N tier is dropped.
+                const scorerState = await getScorerState(fileSessionId, conversation.conversationId);
+                const score = scoreMessage(message, scorerState, {
+                    exploredTargetWindowMs: config.exploredTargetWindowMs,
+                });
+                // Flush dedup state regardless of tier — even N (duplicate)
+                // messages update lastSeenAt on the pattern side; and on first-
+                // seen targets we want to persist before a potential crash.
+                try {
+                    await flushExploredTargets(db, conversation.conversationId, scorerState);
+                }
+                catch (err) {
+                    logger.warn(`flushExploredTargets failed: ${err}`);
+                }
+                if (score.tier === "N") {
+                    logger.debug(`Dropping ${message.role} message (N tier, tags=${score.tags.join(",")})`);
+                    return;
+                }
+                logger.debug(`Ingesting ${message.role} message: tier=${score.tier} tags=${score.tags.join(",")}`);
+                const tokenCount = Math.ceil((score.content || "").length / 4);
+                const insertedMessage = await conversationStore.insertMessage({
+                    conversationId: conversation.conversationId,
+                    role: message.role || "assistant",
+                    content: score.content,
+                    tokenCount,
+                    tier: score.tier,
+                    tags: score.tags,
+                    parts: [{
+                            partType: "text",
+                            textContent: score.content,
+                        }],
+                });
+                try {
+                    await fixAttemptTracker.observeToolUses(message, {
+                        conversationId: conversation.conversationId,
+                        sessionId: fileSessionId,
+                        seq,
+                        messageId: insertedMessage.messageId,
+                    });
+                }
+                catch (err) {
+                    logger.warn(`fixAttemptTracker.observeToolUses failed: ${err}`);
+                }
+                // Async compaction check — fires in background, never blocks ingest.
+                compactor.maybeCompact(conversation.conversationId);
+                // Auto-resolve sweep: any active failure node older than the
+                // staleness window (and with no later recurrence on the same
+                // signature) gets marked resolved. Runs once per ingested
+                // message so the PreToolUse hook stops warning about solved
+                // problems promptly.
+                try {
+                    const resolvedCount = await memoryStore.autoResolveStaleFailureNodes({
+                        conversationId: conversation.conversationId,
+                        currentSeq: seq,
+                        olderThanSeqs: RESOLVE_STALE_WINDOW,
+                        resolution: `auto: no recurrence within ${RESOLVE_STALE_WINDOW} seqs`,
+                    });
+                    if (resolvedCount > 0) {
+                        logger.debug(`auto-resolved ${resolvedCount} stale failure node(s)`);
+                    }
+                }
+                catch (err) {
+                    logger.warn(`autoResolveStaleFailureNodes failed: ${err}`);
+                }
+                // User-signal resolution: if a user message reads as "fixed /
+                // works now / 好了", mark the most recent active failure on
+                // the same target as resolved. This is the explicit closing
+                // signal that complements the staleness sweep.
+                if (message.role === "user" &&
+                    USER_RESOLVED_PATTERNS.some((re) => re.test(message.content || ""))) {
+                    // Most recent mutation tells us which target the user is
+                    // referring to. Without this we'd resolve everything, which
+                    // is too aggressive.
+                    const recentMutation = extractor.getMostRecentMutation();
+                    if (recentMutation) {
+                        try {
+                            const n = await memoryStore.resolveFailureNodesByTarget({
+                                conversationId: conversation.conversationId,
+                                target: {
+                                    filePath: recentMutation.filePath,
+                                    command: recentMutation.command,
+                                },
+                                resolution: `user signaled resolution: "${(message.content || "").slice(0, 80)}"`,
+                                evidenceMessageId: insertedMessage.messageId,
+                            });
+                            if (n > 0) {
+                                logger.debug(`user-resolved ${n} failure node(s)`);
+                            }
+                        }
+                        catch (err) {
+                            logger.warn(`resolveFailureNodesByTarget failed: ${err}`);
+                        }
+                    }
+                }
+                // Extract failure if this is an error and write directly as a
+                // memory_node (kind='failure'). Then check whether a prior
+                // failure with the same anchors should be reopened.
+                const failureNodeIds = [];
+                if (score.tags.includes("error")) {
+                    const extracted = extractor.extractFromErrorMessage(message, conversation.conversationId, seq);
+                    if (extracted) {
+                        logger.debug(`Extracting failure (type=${extracted.type}, file=${extracted.filePath}, cmd=${extracted.command})`);
+                        const failureNode = await memoryStore.createFailureNode({
+                            conversationId: conversation.conversationId,
+                            sessionId: fileSessionId,
+                            seq,
+                            type: extracted.type,
+                            signature: extracted.signature,
+                            raw: extracted.raw,
+                            location: extracted.location,
+                            attemptedFix: extracted.attemptedFix,
+                            filePath: extracted.filePath,
+                            command: extracted.command,
+                            symbol: extracted.symbol,
+                            messageId: extracted.messageId,
+                            evidenceMessageId: insertedMessage.messageId,
+                            weight: 1.0,
+                        });
+                        failureNodeIds.push(failureNode.nodeId);
+                        try {
+                            await lifecycleResolver.reopenFailure({
+                                conversationId: conversation.conversationId,
+                                files: extracted.filePath ? [extracted.filePath] : [],
+                                commands: extracted.command ? [extracted.command] : [],
+                                symbols: extracted.symbol ? [extracted.symbol] : [],
+                                signatures: [extracted.signature],
+                                newFailureNodeId: failureNode.nodeId,
+                                evidenceMessageId: insertedMessage.messageId,
+                                reason: `failure recurred: ${extracted.type} ${extracted.signature.slice(0, 80)}`,
+                            });
+                        }
+                        catch (err) {
+                            logger.warn(`reopenFailure failed: ${err}`);
+                        }
+                    }
+                }
+                const nowMs = Date.now();
+                if (nowMs - lastStaleMaintenanceAt >= STALE_MAINTENANCE_INTERVAL_MS) {
+                    lastStaleMaintenanceAt = nowMs;
+                    try {
+                        const result = await memoryStore.runStaleMaintenance({ limit: 100 });
+                        if (result.staleNodeIds.length > 0) {
+                            logger.debug(`marked ${result.staleNodeIds.length} memory node(s) stale`);
+                        }
+                    }
+                    catch (err) {
+                        logger.warn(`memory stale maintenance failed: ${err}`);
+                    }
+                }
+                try {
+                    await fixAttemptTracker.observeToolResults(message, {
+                        conversationId: conversation.conversationId,
+                        sessionId: fileSessionId,
+                        seq,
+                        messageId: insertedMessage.messageId,
+                        failureNodeIds,
+                    });
+                }
+                catch (err) {
+                    logger.warn(`fixAttemptTracker.observeToolResults failed: ${err}`);
+                }
+            }
+            catch (error) {
+                logger.error(`Failed to ingest message: ${error}`);
+            }
+        };
+        /**
+         * Remove everything a conversation owns, so a re-import rebuilds from a
+         * clean slate rather than layering a second copy on top.
+         *
+         * Deliberately total, including memory nodes. Partial deletion would leave
+         * summary nodes pointing at summaryIds that no longer exist and would let
+         * the failure/fix_attempt extractors re-derive rows that are already
+         * present. The nodes that cannot be rebuilt from a transcript — decisions,
+         * tasks, constraints — are recovered by the extraction pass instead.
+         */
+        const purgeConversation = async (conversationId) => {
+            const nodeIds = `SELECT nodeId FROM memory_nodes WHERE conversationId = ${conversationId}`;
+            const summaryIds = `SELECT summaryId FROM summaries WHERE conversationId = ${conversationId}`;
+            const messageIds = `SELECT messageId FROM conversation_messages WHERE conversationId = ${conversationId}`;
+            const counts = {};
+            const removed = async (table, where) => {
+                const before = await db.get(`SELECT COUNT(*) AS n FROM ${table} WHERE ${where}`);
+                await db.run(`DELETE FROM ${table} WHERE ${where}`);
+                if (before?.n)
+                    counts[table] = before.n;
+            };
+            await db.exec("BEGIN");
+            try {
+                await removed("memory_tags", `nodeId IN (${nodeIds})`);
+                await removed("memory_relations", `fromNodeId IN (${nodeIds}) OR toNodeId IN (${nodeIds})`);
+                await removed("memory_lifecycle_events", `nodeId IN (${nodeIds})`);
+                await removed("memory_pending_updates", `targetNodeId IN (${nodeIds})`);
+                await removed("memory_nodes", `conversationId = ${conversationId}`);
+                await removed("summary_messages", `summaryId IN (${summaryIds})`);
+                await removed("summary_parents", `summaryId IN (${summaryIds}) OR parentSummaryId IN (${summaryIds})`);
+                await removed("summaries", `conversationId = ${conversationId}`);
+                await removed("message_parts", `messageId IN (${messageIds})`);
+                await removed("conversation_messages", `conversationId = ${conversationId}`);
+                await removed("conversation_context", `conversationId = ${conversationId}`);
+                await removed("attempt_spans", `conversationId = ${conversationId}`);
+                await removed("explored_targets", `conversationId = ${conversationId}`);
+                await removed("conversation_bootstrap_state", `conversationId = ${conversationId}`);
+                await removed("conversations", `conversationId = ${conversationId}`);
+                await db.exec("COMMIT");
+            }
+            catch (err) {
+                await db.exec("ROLLBACK");
+                throw err;
+            }
+            return counts;
+        };
+        /**
+         * Recover the memory kinds no deterministic rule produces. Failures here
+         * are logged, not thrown: a session rebuilt without its decisions is worth
+         * more than a re-import that aborts halfway.
+         */
+        const rebuildKeyMemories = async (conversationId, targetSessionId, rawFileContent) => {
+            const counts = { decision: 0, task: 0, constraint: 0, skipped: false };
+            // Prose only — user asks, assistant replies, assistant reasoning. Tool
+            // calls and results are the bulk of a transcript and hold none of the
+            // memory kinds this pass looks for.
+            const transcript = buildExtractionTranscript(rawFileContent);
+            if (!transcript.trim())
+                return counts;
+            logger.info(`[reimport] extraction input is ${transcript.length} chars of prose, from a ${rawFileContent.length}-char transcript`);
+            let extracted;
+            try {
+                extracted = await extractKeyMemories(transcript, {
+                    model: config.compactionModel,
+                    log: logger,
+                });
+            }
+            catch (err) {
+                logger.warn(`[reimport] key-memory extraction failed: ${err}`);
+                counts.skipped = true;
+                return counts;
+            }
+            for (const item of extracted) {
+                try {
+                    if (item.kind === "decision") {
+                        await memoryStore.createDecisionNode({
+                            conversationId,
+                            sessionId: targetSessionId,
+                            decision: item.statement,
+                            rationale: item.rationale,
+                            alternativesRejected: item.alternativesRejected,
+                            content: item.rationale
+                                ? `${item.statement}\n\n${item.rationale}`
+                                : item.statement,
+                        });
+                    }
+                    else if (item.kind === "task") {
+                        await memoryStore.createTaskNode({
+                            conversationId,
+                            sessionId: targetSessionId,
+                            task: item.statement,
+                            details: item.rationale,
+                        });
+                    }
+                    else {
+                        await memoryStore.createConstraintNode({
+                            conversationId,
+                            sessionId: targetSessionId,
+                            constraint: item.statement,
+                            details: item.rationale,
+                        });
+                    }
+                    counts[item.kind]++;
+                }
+                catch (err) {
+                    logger.warn(`[reimport] could not store ${item.kind}: ${err}`);
+                }
+            }
+            logger.info(`[reimport] recovered ${counts.decision} decision(s), ${counts.task} task(s), ${counts.constraint} constraint(s)`);
+            return counts;
+        };
+        /**
+         * Rebuild one session from its transcript: drop what is stored, replay
+         * every line through the same ingest path the watcher uses, then recover
+         * the memory kinds that deterministic rules cannot produce.
+         */
+        const reimportSession = async (targetSessionId) => {
+            if (!watcher)
+                throw new Error("watcher is not running");
+            const filePath = path.join(watcher.watchDirectory, `${targetSessionId}.jsonl`);
+            if (!fs.existsSync(filePath)) {
+                throw new Error(`no transcript at ${filePath}`);
+            }
+            const existing = await conversationStore.getConversationForSession({
+                sessionId: targetSessionId,
+            });
+            const deleted = existing
+                ? await purgeConversation(existing.conversationId)
+                : {};
+            // Per-session in-memory state describes rows that no longer exist.
+            extractors.delete(targetSessionId);
+            scorerStates.delete(targetSessionId);
+            const messages = await watcher.readAllMessages(filePath);
+            for (const message of messages) {
+                await ingestOne(message, filePath);
+            }
+            // The replayed file is now fully consumed; keep the live watcher from
+            // treating it as a backlog on the next poll.
+            await watcher.markFileConsumed(filePath);
+            const rebuilt = await conversationStore.getConversationForSession({
+                sessionId: targetSessionId,
+            });
+            // Deterministic rules have now recovered failures, fix attempts and
+            // summaries. Decisions, tasks and constraints are stated in prose and
+            // have no rule that produces them, so read them back with the model.
+            let keyMemories = { decision: 0, task: 0, constraint: 0, skipped: false };
+            if (rebuilt && !config.compactionDisableLlm) {
+                keyMemories = await rebuildKeyMemories(rebuilt.conversationId, targetSessionId, await fs.promises.readFile(filePath, "utf-8"));
+            }
+            else if (rebuilt) {
+                keyMemories.skipped = true;
+                logger.info("[reimport] key-memory extraction skipped (LLM disabled by configuration)");
+            }
+            const stored = rebuilt
+                ? await db.get("SELECT COUNT(*) AS n FROM conversation_messages WHERE conversationId = ?", rebuilt.conversationId)
+                : { n: 0 };
+            return {
+                sessionId: targetSessionId,
+                transcript: filePath,
+                deleted,
+                linesParsed: messages.length,
+                messagesStored: stored?.n ?? 0,
+                conversationId: rebuilt?.conversationId ?? null,
+                keyMemories,
+            };
+        };
         watcher = await startProjectWatcher(logger, {
             sessionId,
             projectPath,
             pollInterval: 2000,
-            onMessage: async (message, filePath) => {
-                // Get or create conversation for this session
-                const fileName = path.basename(filePath, ".jsonl");
-                const fileSessionId = fileName || sessionId;
-                try {
-                    // Extract phase: observe every message for mutation tracking
-                    // (even if it might be dropped later).
-                    const extractor = getExtractor(fileSessionId);
-                    const conversation = await conversationStore.getOrCreateConversation({
-                        sessionId: fileSessionId,
-                    });
-                    const nextSeqResult = await conversationStore.getDatabase().get(`SELECT MAX(seq) as maxSeq FROM conversation_messages WHERE conversationId = ?`, conversation.conversationId);
-                    const seq = (nextSeqResult?.maxSeq ?? -1) + 1;
-                    extractor.observeMessage(message, seq);
-                    // Filter/Score: decide tier + final content. N tier is dropped.
-                    const scorerState = await getScorerState(fileSessionId, conversation.conversationId);
-                    const score = scoreMessage(message, scorerState, {
-                        exploredTargetWindowMs: config.exploredTargetWindowMs,
-                    });
-                    // Flush dedup state regardless of tier — even N (duplicate)
-                    // messages update lastSeenAt on the pattern side; and on first-
-                    // seen targets we want to persist before a potential crash.
-                    try {
-                        await flushExploredTargets(db, conversation.conversationId, scorerState);
-                    }
-                    catch (err) {
-                        logger.warn(`flushExploredTargets failed: ${err}`);
-                    }
-                    if (score.tier === "N") {
-                        logger.debug(`Dropping ${message.role} message (N tier, tags=${score.tags.join(",")})`);
-                        return;
-                    }
-                    logger.debug(`Ingesting ${message.role} message: tier=${score.tier} tags=${score.tags.join(",")}`);
-                    const tokenCount = Math.ceil((score.content || "").length / 4);
-                    const insertedMessage = await conversationStore.insertMessage({
-                        conversationId: conversation.conversationId,
-                        role: message.role || "assistant",
-                        content: score.content,
-                        tokenCount,
-                        tier: score.tier,
-                        tags: score.tags,
-                        parts: [{
-                                partType: "text",
-                                textContent: score.content,
-                            }],
-                    });
-                    try {
-                        await fixAttemptTracker.observeToolUses(message, {
-                            conversationId: conversation.conversationId,
-                            sessionId: fileSessionId,
-                            seq,
-                            messageId: insertedMessage.messageId,
-                        });
-                    }
-                    catch (err) {
-                        logger.warn(`fixAttemptTracker.observeToolUses failed: ${err}`);
-                    }
-                    // Async compaction check — fires in background, never blocks ingest.
-                    compactor.maybeCompact(conversation.conversationId);
-                    // Auto-resolve sweep: any active failure node older than the
-                    // staleness window (and with no later recurrence on the same
-                    // signature) gets marked resolved. Runs once per ingested
-                    // message so the PreToolUse hook stops warning about solved
-                    // problems promptly.
-                    try {
-                        const resolvedCount = await memoryStore.autoResolveStaleFailureNodes({
-                            conversationId: conversation.conversationId,
-                            currentSeq: seq,
-                            olderThanSeqs: RESOLVE_STALE_WINDOW,
-                            resolution: `auto: no recurrence within ${RESOLVE_STALE_WINDOW} seqs`,
-                        });
-                        if (resolvedCount > 0) {
-                            logger.debug(`auto-resolved ${resolvedCount} stale failure node(s)`);
-                        }
-                    }
-                    catch (err) {
-                        logger.warn(`autoResolveStaleFailureNodes failed: ${err}`);
-                    }
-                    // User-signal resolution: if a user message reads as "fixed /
-                    // works now / 好了", mark the most recent active failure on
-                    // the same target as resolved. This is the explicit closing
-                    // signal that complements the staleness sweep.
-                    if (message.role === "user" &&
-                        USER_RESOLVED_PATTERNS.some((re) => re.test(message.content || ""))) {
-                        // Most recent mutation tells us which target the user is
-                        // referring to. Without this we'd resolve everything, which
-                        // is too aggressive.
-                        const recentMutation = extractor.getMostRecentMutation();
-                        if (recentMutation) {
-                            try {
-                                const n = await memoryStore.resolveFailureNodesByTarget({
-                                    conversationId: conversation.conversationId,
-                                    target: {
-                                        filePath: recentMutation.filePath,
-                                        command: recentMutation.command,
-                                    },
-                                    resolution: `user signaled resolution: "${(message.content || "").slice(0, 80)}"`,
-                                    evidenceMessageId: insertedMessage.messageId,
-                                });
-                                if (n > 0) {
-                                    logger.debug(`user-resolved ${n} failure node(s)`);
-                                }
-                            }
-                            catch (err) {
-                                logger.warn(`resolveFailureNodesByTarget failed: ${err}`);
-                            }
-                        }
-                    }
-                    // Extract failure if this is an error and write directly as a
-                    // memory_node (kind='failure'). Then check whether a prior
-                    // failure with the same anchors should be reopened.
-                    const failureNodeIds = [];
-                    if (score.tags.includes("error")) {
-                        const extracted = extractor.extractFromErrorMessage(message, conversation.conversationId, seq);
-                        if (extracted) {
-                            logger.debug(`Extracting failure (type=${extracted.type}, file=${extracted.filePath}, cmd=${extracted.command})`);
-                            const failureNode = await memoryStore.createFailureNode({
-                                conversationId: conversation.conversationId,
-                                sessionId: fileSessionId,
-                                seq,
-                                type: extracted.type,
-                                signature: extracted.signature,
-                                raw: extracted.raw,
-                                location: extracted.location,
-                                attemptedFix: extracted.attemptedFix,
-                                filePath: extracted.filePath,
-                                command: extracted.command,
-                                symbol: extracted.symbol,
-                                messageId: extracted.messageId,
-                                evidenceMessageId: insertedMessage.messageId,
-                                weight: 1.0,
-                            });
-                            failureNodeIds.push(failureNode.nodeId);
-                            try {
-                                await lifecycleResolver.reopenFailure({
-                                    conversationId: conversation.conversationId,
-                                    files: extracted.filePath ? [extracted.filePath] : [],
-                                    commands: extracted.command ? [extracted.command] : [],
-                                    symbols: extracted.symbol ? [extracted.symbol] : [],
-                                    signatures: [extracted.signature],
-                                    newFailureNodeId: failureNode.nodeId,
-                                    evidenceMessageId: insertedMessage.messageId,
-                                    reason: `failure recurred: ${extracted.type} ${extracted.signature.slice(0, 80)}`,
-                                });
-                            }
-                            catch (err) {
-                                logger.warn(`reopenFailure failed: ${err}`);
-                            }
-                        }
-                    }
-                    const nowMs = Date.now();
-                    if (nowMs - lastStaleMaintenanceAt >= STALE_MAINTENANCE_INTERVAL_MS) {
-                        lastStaleMaintenanceAt = nowMs;
-                        try {
-                            const result = await memoryStore.runStaleMaintenance({ limit: 100 });
-                            if (result.staleNodeIds.length > 0) {
-                                logger.debug(`marked ${result.staleNodeIds.length} memory node(s) stale`);
-                            }
-                        }
-                        catch (err) {
-                            logger.warn(`memory stale maintenance failed: ${err}`);
-                        }
-                    }
-                    try {
-                        await fixAttemptTracker.observeToolResults(message, {
-                            conversationId: conversation.conversationId,
-                            sessionId: fileSessionId,
-                            seq,
-                            messageId: insertedMessage.messageId,
-                            failureNodeIds,
-                        });
-                    }
-                    catch (err) {
-                        logger.warn(`fixAttemptTracker.observeToolResults failed: ${err}`);
-                    }
-                }
-                catch (error) {
-                    logger.error(`Failed to ingest message: ${error}`);
-                }
-            },
+            // Live ingestion only: transcripts already on disk when the daemon
+            // starts are treated as handled, so a restart cannot re-emit their
+            // prefixes as duplicate rows. Gaps are closed with /reimport.
+            seedExistingFilesToEnd: true,
+            onMessage: ingestOne,
         });
         logger.info("Daemon running, watching project directory");
         // Handle shutdown

--- a/dist/hooks/daemon.js
+++ b/dist/hooks/daemon.js
@@ -652,7 +652,7 @@ async function startDaemon(args) {
          * more than a re-import that aborts halfway.
          */
         const rebuildKeyMemories = async (conversationId, targetSessionId, rawFileContent) => {
-            const counts = { decision: 0, task: 0, constraint: 0, skipped: false };
+            const counts = { decision: 0, task: 0, constraint: 0, superseded: 0, skipped: false };
             // Prose only — user asks, assistant replies, assistant reasoning. Tool
             // calls and results are the bulk of a transcript and hold none of the
             // memory kinds this pass looks for.
@@ -672,10 +672,27 @@ async function startDaemon(args) {
                 counts.skipped = true;
                 return counts;
             }
+            // Items arrive in the order they occurred, so a revision always follows
+            // the node it replaces and can resolve to a nodeId that already exists.
+            const nodeIdByStatement = new Map();
+            const statementKey = (kind, statement) => `${kind}:${statement.toLowerCase().replace(/\s+/g, " ")}`;
+            let supersedes = 0;
             for (const item of extracted) {
                 try {
+                    // A session revises itself. Recording only the final position would
+                    // discard how it got there, which is exactly what makes the earlier
+                    // decisions worth keeping — so the replaced node is superseded, not
+                    // deleted, matching what the live mark path does.
+                    let supersedesNodeId;
+                    if (item.revises) {
+                        supersedesNodeId = nodeIdByStatement.get(statementKey(item.kind, item.revises));
+                        if (!supersedesNodeId) {
+                            logger.debug(`[reimport] "${item.statement}" claims to revise an item that was not extracted; storing it standalone`);
+                        }
+                    }
+                    let created;
                     if (item.kind === "decision") {
-                        await memoryStore.createDecisionNode({
+                        created = await memoryStore.createDecisionNode({
                             conversationId,
                             sessionId: targetSessionId,
                             decision: item.statement,
@@ -684,31 +701,38 @@ async function startDaemon(args) {
                             content: item.rationale
                                 ? `${item.statement}\n\n${item.rationale}`
                                 : item.statement,
+                            supersedesNodeId,
                         });
                     }
                     else if (item.kind === "task") {
-                        await memoryStore.createTaskNode({
+                        created = await memoryStore.createTaskNode({
                             conversationId,
                             sessionId: targetSessionId,
                             task: item.statement,
                             details: item.rationale,
+                            supersedesNodeId,
                         });
                     }
                     else {
-                        await memoryStore.createConstraintNode({
+                        created = await memoryStore.createConstraintNode({
                             conversationId,
                             sessionId: targetSessionId,
                             constraint: item.statement,
                             details: item.rationale,
+                            supersedesNodeId,
                         });
                     }
+                    nodeIdByStatement.set(statementKey(item.kind, item.statement), created.nodeId);
                     counts[item.kind]++;
+                    if (supersedesNodeId)
+                        supersedes++;
                 }
                 catch (err) {
                     logger.warn(`[reimport] could not store ${item.kind}: ${err}`);
                 }
             }
-            logger.info(`[reimport] recovered ${counts.decision} decision(s), ${counts.task} task(s), ${counts.constraint} constraint(s)`);
+            counts.superseded = supersedes;
+            logger.info(`[reimport] recovered ${counts.decision} decision(s), ${counts.task} task(s), ${counts.constraint} constraint(s); ${counts.superseded} of them supersede an earlier version`);
             return counts;
         };
         /**
@@ -745,7 +769,7 @@ async function startDaemon(args) {
             // Deterministic rules have now recovered failures, fix attempts and
             // summaries. Decisions, tasks and constraints are stated in prose and
             // have no rule that produces them, so read them back with the model.
-            let keyMemories = { decision: 0, task: 0, constraint: 0, skipped: false };
+            let keyMemories = { decision: 0, task: 0, constraint: 0, superseded: 0, skipped: false };
             if (rebuilt && !config.compactionDisableLlm) {
                 keyMemories = await rebuildKeyMemories(rebuilt.conversationId, targetSessionId, await fs.promises.readFile(filePath, "utf-8"));
             }

--- a/dist/hooks/jsonl-watcher.js
+++ b/dist/hooks/jsonl-watcher.js
@@ -182,6 +182,29 @@ export class CodeMemoryJsonlWatcher {
     /**
      * Read new lines from a JSONL file
      */
+    /**
+     * Resume position for a file, in the same units readNewLines uses.
+     *
+     * The offset map is process-local, so a restart previously rewound every
+     * watched file to 0 and re-emitted its whole prefix. The daemon persists
+     * these values and seeds them back through here.
+     */
+    getOffset(filePath) {
+        return this.watchedFiles.get(filePath) || 0;
+    }
+    seedOffset(filePath, offset) {
+        this.watchedFiles.set(filePath, Math.max(0, offset));
+    }
+    /** Byte-equivalent length of the file as readNewLines measures it. */
+    async currentLength(filePath) {
+        try {
+            const content = await readFile(filePath, "utf-8");
+            return content.length;
+        }
+        catch {
+            return 0;
+        }
+    }
     async readNewLines(filePath) {
         const lastOffset = this.watchedFiles.get(filePath) || 0;
         const lines = await this.readFileLines(filePath, lastOffset);

--- a/dist/hooks/project-watcher-manager.js
+++ b/dist/hooks/project-watcher-manager.js
@@ -8,6 +8,7 @@
  */
 import { createJsonlWatcher } from "./jsonl-watcher.js";
 import { join } from "node:path";
+import { readdir } from "node:fs/promises";
 // Store watchers by session ID
 const watchersBySession = new Map();
 export class ProjectWatcher {
@@ -66,6 +67,9 @@ export class ProjectWatcher {
             this.deps.debug(`[ProjectWatcher] File updated: ${event.filePath}`);
             await this.handleFileUpdate(event.filePath);
         });
+        if (this.options.seedExistingFilesToEnd) {
+            await this.seedExistingFiles();
+        }
         await this.watcher.start();
         this.isRunning = true;
         this.deps.info(`[ProjectWatcher] Started for ${this.options.projectPath}`);
@@ -77,6 +81,50 @@ export class ProjectWatcher {
         this.watcher.stop();
         this.isRunning = false;
         this.deps.info(`[ProjectWatcher] Stopped for ${this.options.projectPath}`);
+    }
+    /**
+     * Mark every transcript present right now as fully read. Done before the
+     * underlying watcher starts, so the initial scan reports no backlog.
+     */
+    /** Directory this watcher observes, so callers can locate a transcript. */
+    get watchDirectory() {
+        return this.projectWatchPath;
+    }
+    /**
+     * Move the read position to the end of a file. Used after a re-import has
+     * replayed it in full, so the next poll does not re-emit the same lines.
+     */
+    async markFileConsumed(filePath) {
+        const length = await this.watcher.currentLength(filePath);
+        this.watcher.seedOffset(filePath, length);
+    }
+    /** Full parse of one transcript, used by the re-import path. */
+    async readAllMessages(filePath) {
+        return this.watcher.readAllLines(filePath);
+    }
+    async seedExistingFiles() {
+        let entries = [];
+        try {
+            entries = await readdir(this.projectWatchPath);
+        }
+        catch (error) {
+            this.deps.warn(`[ProjectWatcher] Could not list ${this.projectWatchPath}: ${error}`);
+            return;
+        }
+        let seeded = 0;
+        for (const name of entries) {
+            if (!name.endsWith(".jsonl"))
+                continue;
+            const filePath = join(this.projectWatchPath, name);
+            const length = await this.watcher.currentLength(filePath);
+            if (length > 0) {
+                this.watcher.seedOffset(filePath, length);
+                seeded++;
+            }
+        }
+        if (seeded > 0) {
+            this.deps.info(`[ProjectWatcher] Treating ${seeded} existing transcript(s) as already ingested; use the re-import command to backfill`);
+        }
     }
     async handleNewFile(filePath) {
         // IMPORTANT: use readNewLines (not readAllLines) here so the offset map

--- a/dist/memory/extract-key-memories.js
+++ b/dist/memory/extract-key-memories.js
@@ -15,20 +15,23 @@ import { buildClaudeCliArgs, claudeCliSpawnEnv, describeClaudeCliFailure, } from
 const DEFAULT_CHUNK_CHARS = 24_000;
 const DEFAULT_MAX_CHUNKS = 20;
 const DEFAULT_TIMEOUT_MS = 60_000;
-const PROMPT = `You are reading an excerpt of a software engineering session transcript.
+const PROMPT = `You are reading an excerpt of a software engineering session transcript, in chronological order.
 
-Extract only durable engineering memory of three kinds:
+Extract durable engineering memory of three kinds:
 - "decision": a technical choice that was committed to (schema shape, library, refactor direction, boundary). Include why, and any alternative explicitly rejected.
 - "task": a non-trivial objective the work is pursuing.
 - "constraint": a hard rule the work must respect (compatibility boundary, performance budget, security or compliance requirement, an explicit must-not).
 
+A session changes its mind. When a later statement replaces an earlier one — a decision reversed, a task retargeted, a constraint relaxed or tightened — report BOTH, in the order they occurred, and set "revises" on the later one to the exact "statement" text of the item it replaces. Do not silently drop the earlier version: how the work arrived at its position is part of the record.
+
 Rules:
 - Extract only what the transcript states or clearly commits to. Never infer, generalize, or invent.
-- Skip trivia, exploratory musing, and anything later abandoned in the same excerpt.
+- List items in the order they appear.
+- Skip trivia and exploratory musing that was never committed to.
 - Prefer few high-value items over many weak ones. An excerpt with nothing durable yields an empty list.
 
 Reply with JSON only, no prose and no code fence:
-{"items":[{"kind":"decision|task|constraint","statement":"...","rationale":"...","alternativesRejected":["..."]}]}`;
+{"items":[{"kind":"decision|task|constraint","statement":"...","rationale":"...","alternativesRejected":["..."],"revises":"..."}]}`;
 /**
  * Build the text an extraction pass should read, straight from the raw
  * transcript.
@@ -94,7 +97,15 @@ export async function extractKeyMemories(transcript, options = {}) {
     const collected = [];
     for (let i = 0; i < chunks.length; i++) {
         try {
-            const raw = await runClaude(`${PROMPT}\n\n--- transcript excerpt ${i + 1}/${chunks.length} ---\n${chunks[i]}`, options);
+            // Carry what earlier chunks produced into this one. Without it a
+            // revision can only ever be spotted inside a single excerpt, and a
+            // decision reversed two chunks later reads as an unrelated second
+            // decision.
+            const priorContext = collected.length > 0
+                ? `\n\n--- already extracted from earlier excerpts (set "revises" to one of these statements if this excerpt replaces it) ---\n` +
+                    collected.map((m) => `- [${m.kind}] ${m.statement}`).join("\n")
+                : "";
+            const raw = await runClaude(`${PROMPT}${priorContext}\n\n--- transcript excerpt ${i + 1}/${chunks.length} ---\n${chunks[i]}`, options);
             collected.push(...parseItems(raw));
         }
         catch (error) {
@@ -153,15 +164,32 @@ function parseItems(raw) {
             alternativesRejected: Array.isArray(item?.alternativesRejected)
                 ? item.alternativesRejected.filter((a) => typeof a === "string")
                 : undefined,
+            revises: typeof item?.revises === "string" && item.revises.trim()
+                ? item.revises.trim()
+                : undefined,
         };
     })
         .filter((x) => x !== null);
 }
-/** Chunks overlap in subject matter, so the same decision can be reported twice. */
+/**
+ * Collapse only exact restatements — the same item reported twice because
+ * chunks overlap in subject matter.
+ *
+ * An item carrying `revises` is never folded away even if its statement
+ * matches something seen before: it is a distinct point in the session's
+ * history, and dropping it would flatten the revision chain this pass exists
+ * to preserve. Order is preserved throughout, because the rebuild creates
+ * nodes in sequence and each supersede has to land on a node that already
+ * exists.
+ */
 function dedupe(items) {
     const seen = new Set();
     const out = [];
     for (const item of items) {
+        if (item.revises) {
+            out.push(item);
+            continue;
+        }
         const key = `${item.kind}:${item.statement.toLowerCase().replace(/\s+/g, " ")}`;
         if (seen.has(key))
             continue;

--- a/dist/memory/extract-key-memories.js
+++ b/dist/memory/extract-key-memories.js
@@ -1,0 +1,213 @@
+/**
+ * CodeMemory for Claude Code - Key memory extraction for re-import
+ *
+ * A re-import rebuilds a session from its transcript. The deterministic
+ * extractors recover failures, fix attempts and summaries, because those are
+ * derivable from tool results and errors. Decisions, tasks and constraints are
+ * not: they are stated in prose, and until now the only way they entered the
+ * store was a mark skill the model had to choose to invoke.
+ *
+ * A full-delete re-import would therefore lose them permanently, so this pass
+ * reads them back out of the transcript with an LLM.
+ */
+import { spawn } from "node:child_process";
+import { buildClaudeCliArgs, claudeCliSpawnEnv, describeClaudeCliFailure, } from "../llm/claude-cli.js";
+const DEFAULT_CHUNK_CHARS = 24_000;
+const DEFAULT_MAX_CHUNKS = 20;
+const DEFAULT_TIMEOUT_MS = 60_000;
+const PROMPT = `You are reading an excerpt of a software engineering session transcript.
+
+Extract only durable engineering memory of three kinds:
+- "decision": a technical choice that was committed to (schema shape, library, refactor direction, boundary). Include why, and any alternative explicitly rejected.
+- "task": a non-trivial objective the work is pursuing.
+- "constraint": a hard rule the work must respect (compatibility boundary, performance budget, security or compliance requirement, an explicit must-not).
+
+Rules:
+- Extract only what the transcript states or clearly commits to. Never infer, generalize, or invent.
+- Skip trivia, exploratory musing, and anything later abandoned in the same excerpt.
+- Prefer few high-value items over many weak ones. An excerpt with nothing durable yields an empty list.
+
+Reply with JSON only, no prose and no code fence:
+{"items":[{"kind":"decision|task|constraint","statement":"...","rationale":"...","alternativesRejected":["..."]}]}`;
+/**
+ * Build the text an extraction pass should read, straight from the raw
+ * transcript.
+ *
+ * Only prose carries decisions, tasks and constraints: what the user asked
+ * for, what the assistant said, and what it reasoned about. Tool calls and
+ * tool results are the bulk of a transcript — 682 of 1096 content parts in a
+ * real session here — and contain none of it, so feeding them to the model
+ * costs tokens and dilutes the signal.
+ *
+ * This reads the file directly rather than reusing the ingest parser, for two
+ * reasons: that parser drops `thinking` blocks entirely (221 of them in the
+ * same session), and it renders tool calls into the flattened content string,
+ * which would be the opposite of what is wanted here.
+ */
+export function buildExtractionTranscript(rawFileContent) {
+    const out = [];
+    for (const line of rawFileContent.split("\n")) {
+        if (!line.trim())
+            continue;
+        let entry;
+        try {
+            entry = JSON.parse(line);
+        }
+        catch {
+            continue;
+        }
+        const role = entry?.message?.role ?? entry?.type;
+        if (role !== "user" && role !== "assistant")
+            continue;
+        // Subagent chatter is not this session's engineering record.
+        if (entry?.isSidechain)
+            continue;
+        const content = entry?.message?.content;
+        const segments = [];
+        if (typeof content === "string") {
+            segments.push(content);
+        }
+        else if (Array.isArray(content)) {
+            for (const part of content) {
+                if (part?.type === "text" && typeof part.text === "string") {
+                    segments.push(part.text);
+                }
+                else if (part?.type === "thinking" && typeof part.thinking === "string") {
+                    segments.push(`(reasoning) ${part.thinking}`);
+                }
+                // tool_use and tool_result are intentionally skipped.
+            }
+        }
+        const text = segments.join("\n").trim();
+        if (text)
+            out.push(`[${role.toUpperCase()}] ${text}`);
+    }
+    return out.join("\n\n");
+}
+export async function extractKeyMemories(transcript, options = {}) {
+    const chunkChars = options.chunkChars ?? DEFAULT_CHUNK_CHARS;
+    const maxChunks = options.maxChunks ?? DEFAULT_MAX_CHUNKS;
+    const chunks = chunkTranscript(transcript, chunkChars).slice(0, maxChunks);
+    if (chunks.length === 0)
+        return [];
+    options.log?.info(`[reimport] extracting key memories from ${chunks.length} chunk(s)`);
+    const collected = [];
+    for (let i = 0; i < chunks.length; i++) {
+        try {
+            const raw = await runClaude(`${PROMPT}\n\n--- transcript excerpt ${i + 1}/${chunks.length} ---\n${chunks[i]}`, options);
+            collected.push(...parseItems(raw));
+        }
+        catch (error) {
+            // One bad chunk must not discard the rest: a partial rebuild of these
+            // nodes is better than none, and the failure is visible in the log.
+            options.log?.warn(`[reimport] key-memory extraction failed on chunk ${i + 1}/${chunks.length}: ${error}`);
+        }
+    }
+    return dedupe(collected);
+}
+/** Split on line boundaries so a record is never cut mid-way. */
+function chunkTranscript(transcript, chunkChars) {
+    const lines = transcript.split("\n").filter((l) => l.trim());
+    const chunks = [];
+    let current = [];
+    let size = 0;
+    for (const line of lines) {
+        if (size + line.length > chunkChars && current.length > 0) {
+            chunks.push(current.join("\n"));
+            current = [];
+            size = 0;
+        }
+        current.push(line);
+        size += line.length + 1;
+    }
+    if (current.length > 0)
+        chunks.push(current.join("\n"));
+    return chunks;
+}
+function parseItems(raw) {
+    const text = raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/```\s*$/, "");
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start === -1 || end <= start)
+        return [];
+    let parsed;
+    try {
+        parsed = JSON.parse(text.slice(start, end + 1));
+    }
+    catch {
+        return [];
+    }
+    const items = Array.isArray(parsed?.items) ? parsed.items : [];
+    return items
+        .map((item) => {
+        const kind = item?.kind;
+        const statement = typeof item?.statement === "string" ? item.statement.trim() : "";
+        if (kind !== "decision" && kind !== "task" && kind !== "constraint")
+            return null;
+        if (!statement)
+            return null;
+        return {
+            kind,
+            statement,
+            rationale: typeof item?.rationale === "string" ? item.rationale.trim() : "",
+            alternativesRejected: Array.isArray(item?.alternativesRejected)
+                ? item.alternativesRejected.filter((a) => typeof a === "string")
+                : undefined,
+        };
+    })
+        .filter((x) => x !== null);
+}
+/** Chunks overlap in subject matter, so the same decision can be reported twice. */
+function dedupe(items) {
+    const seen = new Set();
+    const out = [];
+    for (const item of items) {
+        const key = `${item.kind}:${item.statement.toLowerCase().replace(/\s+/g, " ")}`;
+        if (seen.has(key))
+            continue;
+        seen.add(key);
+        out.push(item);
+    }
+    return out;
+}
+function runClaude(prompt, options) {
+    return new Promise((resolve, reject) => {
+        const child = spawn("claude", buildClaudeCliArgs(options.model), {
+            stdio: ["pipe", "pipe", "pipe"],
+            env: claudeCliSpawnEnv(),
+        });
+        const stdout = [];
+        const stderr = [];
+        let settled = false;
+        const timer = setTimeout(() => {
+            if (settled)
+                return;
+            settled = true;
+            child.kill("SIGTERM");
+            reject(new Error(`timed out after ${options.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms`));
+        }, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+        child.stdout.on("data", (c) => stdout.push(c));
+        child.stderr.on("data", (c) => stderr.push(c));
+        child.on("error", (err) => {
+            if (settled)
+                return;
+            settled = true;
+            clearTimeout(timer);
+            reject(err);
+        });
+        child.on("close", (code) => {
+            if (settled)
+                return;
+            settled = true;
+            clearTimeout(timer);
+            if (code !== 0) {
+                reject(new Error(`claude --print exited with code ${code}: ${describeClaudeCliFailure(Buffer.concat(stdout).toString("utf-8"), Buffer.concat(stderr).toString("utf-8"))}`));
+                return;
+            }
+            resolve(Buffer.concat(stdout).toString("utf-8").trim());
+        });
+        child.stdin.write(prompt);
+        child.stdin.end();
+    });
+}
+//# sourceMappingURL=extract-key-memories.js.map

--- a/hooks/scripts/codememory-reimport.sh
+++ b/hooks/scripts/codememory-reimport.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# CodeMemory - Re-import a session from its transcript.
+#
+# Destructive by design: everything the session owns is deleted and rebuilt
+# from the jsonl on disk. That is what makes it idempotent — running it twice
+# leaves the same rows as running it once.
+#
+# The daemon does no backfill on startup, so this is how a gap gets closed:
+# a session that ran while the daemon was down, or one whose stored data is
+# suspect.
+
+set -euo pipefail
+
+LOG_DIR="${HOME}/.claude/codememory-logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="${LOG_DIR}/reimport.log"
+
+TARGET_SESSION="${1:-${CLAUDE_SESSION_ID:-}}"
+RUNTIME_DIR="${HOME}/.claude/codememory-runtime"
+
+if [ -z "$TARGET_SESSION" ]; then
+  echo '{"ok":false,"error":"no session id given and CLAUDE_SESSION_ID is unset"}'
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo '{"ok":false,"error":"curl is required"}'
+  exit 0
+fi
+
+# Prefer this session's own daemon; fall back to the most recently active one,
+# since the transcript being rebuilt may belong to a different session in the
+# same project.
+SOCKET=""
+if [ -S "$RUNTIME_DIR/${CLAUDE_SESSION_ID:-none}.sock" ]; then
+  SOCKET="$RUNTIME_DIR/${CLAUDE_SESSION_ID}.sock"
+else
+  while IFS= read -r candidate; do
+    [ -S "$candidate" ] && SOCKET="$candidate" && break
+  done < <(ls -t "$RUNTIME_DIR"/*.sock 2>/dev/null || true)
+fi
+
+if [ -z "$SOCKET" ]; then
+  echo '{"ok":false,"error":"no live CodeMemory daemon socket under ~/.claude/codememory-runtime/"}'
+  exit 0
+fi
+
+echo "[$(date -Iseconds)] reimport requested for $TARGET_SESSION via $SOCKET" >> "$LOG_FILE"
+
+PAYLOAD=$(jq -nc --arg sid "$TARGET_SESSION" '{sessionId: $sid}')
+RESPONSE=$(curl -sS --unix-socket "$SOCKET" --max-time 600 \
+  -H 'content-type: application/json' --data "$PAYLOAD" \
+  http://localhost/reimport 2>>"$LOG_FILE") || RESPONSE=''
+
+if [ -z "$RESPONSE" ]; then
+  echo '{"ok":false,"error":"daemon did not respond; see ~/.claude/codememory-logs/reimport.log"}'
+  exit 0
+fi
+
+echo "[$(date -Iseconds)] $RESPONSE" >> "$LOG_FILE"
+printf '%s\n' "$RESPONSE"

--- a/src/hooks/daemon.ts
+++ b/src/hooks/daemon.ts
@@ -11,6 +11,11 @@ import * as http from "node:http";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { startProjectWatcher, ProjectWatcher } from "./project-watcher-manager.js";
+import type { JsonlMessage } from "./jsonl-watcher.js";
+import {
+  buildExtractionTranscript,
+  extractKeyMemories,
+} from "../memory/extract-key-memories.js";
 import { resolveCodeMemoryConfig } from "../db/config.js";
 import { createCodeMemoryDatabaseConnection } from "../db/connection.js";
 import { ConversationStore } from "../store/conversation-store.js";
@@ -245,6 +250,33 @@ async function startDaemon(args: string[]) {
       // SessionEnd hooks. Body is optional JSON `{sessionId?}`; defaults to
       // the daemon's own sessionId. Fire-and-forget: we 202 immediately and
       // run the work in the background so the hook never blocks the user.
+      if (req.url === "/reimport") {
+        const chunks: Buffer[] = [];
+        req.on("data", (c) => chunks.push(c));
+        req.on("end", async () => {
+          try {
+            const raw = Buffer.concat(chunks).toString("utf-8").trim();
+            const body = raw ? JSON.parse(raw) : {};
+            const target =
+              typeof body.sessionId === "string" && body.sessionId
+                ? body.sessionId
+                : sessionId;
+
+            logger.info(`[reimport] rebuilding session ${target}`);
+            const result = await reimportSession(target);
+            logger.info(`[reimport] ${JSON.stringify(result)}`);
+
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true, ...result }));
+          } catch (err) {
+            logger.error(`[reimport] failed: ${err}`);
+            res.writeHead(500, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: String(err) }));
+          }
+        });
+        return;
+      }
+
       if (req.url === "/compact") {
         const chunks: Buffer[] = [];
         req.on("data", (c) => chunks.push(c));
@@ -459,220 +491,440 @@ async function startDaemon(args: string[]) {
       return e;
     };
 
+    /**
+     * The one place a transcript line becomes rows. The watcher calls it
+     * live; /reimport calls it again when rebuilding a session from its
+     * jsonl, so both paths cannot drift apart.
+     */
+    const ingestOne = async (
+      message: JsonlMessage,
+      filePath: string
+    ): Promise<void> => {
+      // Get or create conversation for this session
+      const fileName = path.basename(filePath, ".jsonl");
+      const fileSessionId = fileName || sessionId;
+
+      try {
+        // Extract phase: observe every message for mutation tracking
+        // (even if it might be dropped later).
+        const extractor = getExtractor(fileSessionId);
+        const conversation = await conversationStore.getOrCreateConversation({
+          sessionId: fileSessionId,
+        });
+        const nextSeqResult = await conversationStore.getDatabase().get(
+          `SELECT MAX(seq) as maxSeq FROM conversation_messages WHERE conversationId = ?`,
+          conversation.conversationId
+        );
+        const seq = (nextSeqResult?.maxSeq ?? -1) + 1;
+        extractor.observeMessage(message, seq);
+
+        // Filter/Score: decide tier + final content. N tier is dropped.
+        const scorerState = await getScorerState(
+          fileSessionId,
+          conversation.conversationId
+        );
+        const score = scoreMessage(message, scorerState, {
+          exploredTargetWindowMs: config.exploredTargetWindowMs,
+        });
+        // Flush dedup state regardless of tier — even N (duplicate)
+        // messages update lastSeenAt on the pattern side; and on first-
+        // seen targets we want to persist before a potential crash.
+        try {
+          await flushExploredTargets(
+            db,
+            conversation.conversationId,
+            scorerState
+          );
+        } catch (err) {
+          logger.warn(`flushExploredTargets failed: ${err}`);
+        }
+        if (score.tier === "N") {
+          logger.debug(
+            `Dropping ${message.role} message (N tier, tags=${score.tags.join(",")})`
+          );
+          return;
+        }
+
+        logger.debug(
+          `Ingesting ${message.role} message: tier=${score.tier} tags=${score.tags.join(",")}`
+        );
+
+        const tokenCount = Math.ceil((score.content || "").length / 4);
+
+        const insertedMessage = await conversationStore.insertMessage({
+          conversationId: conversation.conversationId,
+          role: message.role || "assistant",
+          content: score.content,
+          tokenCount,
+          tier: score.tier,
+          tags: score.tags,
+          parts: [{
+            partType: "text",
+            textContent: score.content,
+          }],
+        });
+
+        try {
+          await fixAttemptTracker.observeToolUses(message, {
+            conversationId: conversation.conversationId,
+            sessionId: fileSessionId,
+            seq,
+            messageId: insertedMessage.messageId,
+          });
+        } catch (err) {
+          logger.warn(`fixAttemptTracker.observeToolUses failed: ${err}`);
+        }
+
+        // Async compaction check — fires in background, never blocks ingest.
+        compactor.maybeCompact(conversation.conversationId);
+
+        // Auto-resolve sweep: any active failure node older than the
+        // staleness window (and with no later recurrence on the same
+        // signature) gets marked resolved. Runs once per ingested
+        // message so the PreToolUse hook stops warning about solved
+        // problems promptly.
+        try {
+          const resolvedCount = await memoryStore.autoResolveStaleFailureNodes({
+            conversationId: conversation.conversationId,
+            currentSeq: seq,
+            olderThanSeqs: RESOLVE_STALE_WINDOW,
+            resolution: `auto: no recurrence within ${RESOLVE_STALE_WINDOW} seqs`,
+          });
+          if (resolvedCount > 0) {
+            logger.debug(
+              `auto-resolved ${resolvedCount} stale failure node(s)`
+            );
+          }
+        } catch (err) {
+          logger.warn(`autoResolveStaleFailureNodes failed: ${err}`);
+        }
+
+        // User-signal resolution: if a user message reads as "fixed /
+        // works now / 好了", mark the most recent active failure on
+        // the same target as resolved. This is the explicit closing
+        // signal that complements the staleness sweep.
+        if (
+          message.role === "user" &&
+          USER_RESOLVED_PATTERNS.some((re) => re.test(message.content || ""))
+        ) {
+          // Most recent mutation tells us which target the user is
+          // referring to. Without this we'd resolve everything, which
+          // is too aggressive.
+          const recentMutation = extractor.getMostRecentMutation();
+          if (recentMutation) {
+            try {
+              const n = await memoryStore.resolveFailureNodesByTarget({
+                conversationId: conversation.conversationId,
+                target: {
+                  filePath: recentMutation.filePath,
+                  command: recentMutation.command,
+                },
+                resolution: `user signaled resolution: "${(message.content || "").slice(0, 80)}"`,
+                evidenceMessageId: insertedMessage.messageId,
+              });
+              if (n > 0) {
+                logger.debug(`user-resolved ${n} failure node(s)`);
+              }
+            } catch (err) {
+              logger.warn(`resolveFailureNodesByTarget failed: ${err}`);
+            }
+          }
+        }
+
+        // Extract failure if this is an error and write directly as a
+        // memory_node (kind='failure'). Then check whether a prior
+        // failure with the same anchors should be reopened.
+        const failureNodeIds: string[] = [];
+        if (score.tags.includes("error")) {
+          const extracted = extractor.extractFromErrorMessage(
+            message,
+            conversation.conversationId,
+            seq
+          );
+          if (extracted) {
+            logger.debug(
+              `Extracting failure (type=${extracted.type}, file=${extracted.filePath}, cmd=${extracted.command})`
+            );
+            const failureNode = await memoryStore.createFailureNode({
+              conversationId: conversation.conversationId,
+              sessionId: fileSessionId,
+              seq,
+              type: extracted.type,
+              signature: extracted.signature,
+              raw: extracted.raw,
+              location: extracted.location,
+              attemptedFix: extracted.attemptedFix,
+              filePath: extracted.filePath,
+              command: extracted.command,
+              symbol: extracted.symbol,
+              messageId: extracted.messageId,
+              evidenceMessageId: insertedMessage.messageId,
+              weight: 1.0,
+            });
+            failureNodeIds.push(failureNode.nodeId);
+            try {
+              await lifecycleResolver.reopenFailure({
+                conversationId: conversation.conversationId,
+                files: extracted.filePath ? [extracted.filePath] : [],
+                commands: extracted.command ? [extracted.command] : [],
+                symbols: extracted.symbol ? [extracted.symbol] : [],
+                signatures: [extracted.signature],
+                newFailureNodeId: failureNode.nodeId,
+                evidenceMessageId: insertedMessage.messageId,
+                reason: `failure recurred: ${extracted.type} ${extracted.signature.slice(0, 80)}`,
+              });
+            } catch (err) {
+              logger.warn(`reopenFailure failed: ${err}`);
+            }
+          }
+        }
+
+        const nowMs = Date.now();
+        if (nowMs - lastStaleMaintenanceAt >= STALE_MAINTENANCE_INTERVAL_MS) {
+          lastStaleMaintenanceAt = nowMs;
+          try {
+            const result = await memoryStore.runStaleMaintenance({ limit: 100 });
+            if (result.staleNodeIds.length > 0) {
+              logger.debug(
+                `marked ${result.staleNodeIds.length} memory node(s) stale`
+              );
+            }
+          } catch (err) {
+            logger.warn(`memory stale maintenance failed: ${err}`);
+          }
+        }
+
+        try {
+          await fixAttemptTracker.observeToolResults(message, {
+            conversationId: conversation.conversationId,
+            sessionId: fileSessionId,
+            seq,
+            messageId: insertedMessage.messageId,
+            failureNodeIds,
+          });
+        } catch (err) {
+          logger.warn(`fixAttemptTracker.observeToolResults failed: ${err}`);
+        }
+      } catch (error) {
+        logger.error(`Failed to ingest message: ${error}`);
+      }
+    };
+
+    /**
+     * Remove everything a conversation owns, so a re-import rebuilds from a
+     * clean slate rather than layering a second copy on top.
+     *
+     * Deliberately total, including memory nodes. Partial deletion would leave
+     * summary nodes pointing at summaryIds that no longer exist and would let
+     * the failure/fix_attempt extractors re-derive rows that are already
+     * present. The nodes that cannot be rebuilt from a transcript — decisions,
+     * tasks, constraints — are recovered by the extraction pass instead.
+     */
+    const purgeConversation = async (
+      conversationId: number
+    ): Promise<Record<string, number>> => {
+      const nodeIds = `SELECT nodeId FROM memory_nodes WHERE conversationId = ${conversationId}`;
+      const summaryIds = `SELECT summaryId FROM summaries WHERE conversationId = ${conversationId}`;
+      const messageIds = `SELECT messageId FROM conversation_messages WHERE conversationId = ${conversationId}`;
+
+      const counts: Record<string, number> = {};
+      const removed = async (table: string, where: string) => {
+        const before = await db.get(`SELECT COUNT(*) AS n FROM ${table} WHERE ${where}`);
+        await db.run(`DELETE FROM ${table} WHERE ${where}`);
+        if (before?.n) counts[table] = before.n;
+      };
+
+      await db.exec("BEGIN");
+      try {
+        await removed("memory_tags", `nodeId IN (${nodeIds})`);
+        await removed(
+          "memory_relations",
+          `fromNodeId IN (${nodeIds}) OR toNodeId IN (${nodeIds})`
+        );
+        await removed("memory_lifecycle_events", `nodeId IN (${nodeIds})`);
+        await removed("memory_pending_updates", `targetNodeId IN (${nodeIds})`);
+        await removed("memory_nodes", `conversationId = ${conversationId}`);
+
+        await removed("summary_messages", `summaryId IN (${summaryIds})`);
+        await removed(
+          "summary_parents",
+          `summaryId IN (${summaryIds}) OR parentSummaryId IN (${summaryIds})`
+        );
+        await removed("summaries", `conversationId = ${conversationId}`);
+
+        await removed("message_parts", `messageId IN (${messageIds})`);
+        await removed("conversation_messages", `conversationId = ${conversationId}`);
+        await removed("conversation_context", `conversationId = ${conversationId}`);
+        await removed("attempt_spans", `conversationId = ${conversationId}`);
+        await removed("explored_targets", `conversationId = ${conversationId}`);
+        await removed(
+          "conversation_bootstrap_state",
+          `conversationId = ${conversationId}`
+        );
+        await removed("conversations", `conversationId = ${conversationId}`);
+        await db.exec("COMMIT");
+      } catch (err) {
+        await db.exec("ROLLBACK");
+        throw err;
+      }
+      return counts;
+    };
+
+    /**
+     * Recover the memory kinds no deterministic rule produces. Failures here
+     * are logged, not thrown: a session rebuilt without its decisions is worth
+     * more than a re-import that aborts halfway.
+     */
+    const rebuildKeyMemories = async (
+      conversationId: number,
+      targetSessionId: string,
+      rawFileContent: string
+    ): Promise<{ decision: number; task: number; constraint: number; skipped: boolean }> => {
+      const counts = { decision: 0, task: 0, constraint: 0, skipped: false };
+      // Prose only — user asks, assistant replies, assistant reasoning. Tool
+      // calls and results are the bulk of a transcript and hold none of the
+      // memory kinds this pass looks for.
+      const transcript = buildExtractionTranscript(rawFileContent);
+      if (!transcript.trim()) return counts;
+
+      logger.info(
+        `[reimport] extraction input is ${transcript.length} chars of prose, from a ${rawFileContent.length}-char transcript`
+      );
+
+      let extracted;
+      try {
+        extracted = await extractKeyMemories(transcript, {
+          model: config.compactionModel,
+          log: logger,
+        });
+      } catch (err) {
+        logger.warn(`[reimport] key-memory extraction failed: ${err}`);
+        counts.skipped = true;
+        return counts;
+      }
+
+      for (const item of extracted) {
+        try {
+          if (item.kind === "decision") {
+            await memoryStore.createDecisionNode({
+              conversationId,
+              sessionId: targetSessionId,
+              decision: item.statement,
+              rationale: item.rationale,
+              alternativesRejected: item.alternativesRejected,
+              content: item.rationale
+                ? `${item.statement}\n\n${item.rationale}`
+                : item.statement,
+            });
+          } else if (item.kind === "task") {
+            await memoryStore.createTaskNode({
+              conversationId,
+              sessionId: targetSessionId,
+              task: item.statement,
+              details: item.rationale,
+            });
+          } else {
+            await memoryStore.createConstraintNode({
+              conversationId,
+              sessionId: targetSessionId,
+              constraint: item.statement,
+              details: item.rationale,
+            });
+          }
+          counts[item.kind]++;
+        } catch (err) {
+          logger.warn(`[reimport] could not store ${item.kind}: ${err}`);
+        }
+      }
+
+      logger.info(
+        `[reimport] recovered ${counts.decision} decision(s), ${counts.task} task(s), ${counts.constraint} constraint(s)`
+      );
+      return counts;
+    };
+
+    /**
+     * Rebuild one session from its transcript: drop what is stored, replay
+     * every line through the same ingest path the watcher uses, then recover
+     * the memory kinds that deterministic rules cannot produce.
+     */
+    const reimportSession = async (
+      targetSessionId: string
+    ): Promise<Record<string, unknown>> => {
+      if (!watcher) throw new Error("watcher is not running");
+
+      const filePath = path.join(watcher.watchDirectory, `${targetSessionId}.jsonl`);
+      if (!fs.existsSync(filePath)) {
+        throw new Error(`no transcript at ${filePath}`);
+      }
+
+      const existing = await conversationStore.getConversationForSession({
+        sessionId: targetSessionId,
+      });
+      const deleted = existing
+        ? await purgeConversation(existing.conversationId)
+        : {};
+
+      // Per-session in-memory state describes rows that no longer exist.
+      extractors.delete(targetSessionId);
+      scorerStates.delete(targetSessionId);
+
+      const messages = await watcher.readAllMessages(filePath);
+      for (const message of messages) {
+        await ingestOne(message, filePath);
+      }
+
+      // The replayed file is now fully consumed; keep the live watcher from
+      // treating it as a backlog on the next poll.
+      await watcher.markFileConsumed(filePath);
+
+      const rebuilt = await conversationStore.getConversationForSession({
+        sessionId: targetSessionId,
+      });
+
+      // Deterministic rules have now recovered failures, fix attempts and
+      // summaries. Decisions, tasks and constraints are stated in prose and
+      // have no rule that produces them, so read them back with the model.
+      let keyMemories = { decision: 0, task: 0, constraint: 0, skipped: false };
+      if (rebuilt && !config.compactionDisableLlm) {
+        keyMemories = await rebuildKeyMemories(
+          rebuilt.conversationId,
+          targetSessionId,
+          await fs.promises.readFile(filePath, "utf-8")
+        );
+      } else if (rebuilt) {
+        keyMemories.skipped = true;
+        logger.info(
+          "[reimport] key-memory extraction skipped (LLM disabled by configuration)"
+        );
+      }
+      const stored = rebuilt
+        ? await db.get(
+            "SELECT COUNT(*) AS n FROM conversation_messages WHERE conversationId = ?",
+            rebuilt.conversationId
+          )
+        : { n: 0 };
+
+      return {
+        sessionId: targetSessionId,
+        transcript: filePath,
+        deleted,
+        linesParsed: messages.length,
+        messagesStored: stored?.n ?? 0,
+        conversationId: rebuilt?.conversationId ?? null,
+        keyMemories,
+      };
+    };
+
     watcher = await startProjectWatcher(logger, {
       sessionId,
       projectPath,
       pollInterval: 2000,
-      onMessage: async (message, filePath) => {
-        // Get or create conversation for this session
-        const fileName = path.basename(filePath, ".jsonl");
-        const fileSessionId = fileName || sessionId;
-
-        try {
-          // Extract phase: observe every message for mutation tracking
-          // (even if it might be dropped later).
-          const extractor = getExtractor(fileSessionId);
-          const conversation = await conversationStore.getOrCreateConversation({
-            sessionId: fileSessionId,
-          });
-          const nextSeqResult = await conversationStore.getDatabase().get(
-            `SELECT MAX(seq) as maxSeq FROM conversation_messages WHERE conversationId = ?`,
-            conversation.conversationId
-          );
-          const seq = (nextSeqResult?.maxSeq ?? -1) + 1;
-          extractor.observeMessage(message, seq);
-
-          // Filter/Score: decide tier + final content. N tier is dropped.
-          const scorerState = await getScorerState(
-            fileSessionId,
-            conversation.conversationId
-          );
-          const score = scoreMessage(message, scorerState, {
-            exploredTargetWindowMs: config.exploredTargetWindowMs,
-          });
-          // Flush dedup state regardless of tier — even N (duplicate)
-          // messages update lastSeenAt on the pattern side; and on first-
-          // seen targets we want to persist before a potential crash.
-          try {
-            await flushExploredTargets(
-              db,
-              conversation.conversationId,
-              scorerState
-            );
-          } catch (err) {
-            logger.warn(`flushExploredTargets failed: ${err}`);
-          }
-          if (score.tier === "N") {
-            logger.debug(
-              `Dropping ${message.role} message (N tier, tags=${score.tags.join(",")})`
-            );
-            return;
-          }
-
-          logger.debug(
-            `Ingesting ${message.role} message: tier=${score.tier} tags=${score.tags.join(",")}`
-          );
-
-          const tokenCount = Math.ceil((score.content || "").length / 4);
-
-          const insertedMessage = await conversationStore.insertMessage({
-            conversationId: conversation.conversationId,
-            role: message.role || "assistant",
-            content: score.content,
-            tokenCount,
-            tier: score.tier,
-            tags: score.tags,
-            parts: [{
-              partType: "text",
-              textContent: score.content,
-            }],
-          });
-
-          try {
-            await fixAttemptTracker.observeToolUses(message, {
-              conversationId: conversation.conversationId,
-              sessionId: fileSessionId,
-              seq,
-              messageId: insertedMessage.messageId,
-            });
-          } catch (err) {
-            logger.warn(`fixAttemptTracker.observeToolUses failed: ${err}`);
-          }
-
-          // Async compaction check — fires in background, never blocks ingest.
-          compactor.maybeCompact(conversation.conversationId);
-
-          // Auto-resolve sweep: any active failure node older than the
-          // staleness window (and with no later recurrence on the same
-          // signature) gets marked resolved. Runs once per ingested
-          // message so the PreToolUse hook stops warning about solved
-          // problems promptly.
-          try {
-            const resolvedCount = await memoryStore.autoResolveStaleFailureNodes({
-              conversationId: conversation.conversationId,
-              currentSeq: seq,
-              olderThanSeqs: RESOLVE_STALE_WINDOW,
-              resolution: `auto: no recurrence within ${RESOLVE_STALE_WINDOW} seqs`,
-            });
-            if (resolvedCount > 0) {
-              logger.debug(
-                `auto-resolved ${resolvedCount} stale failure node(s)`
-              );
-            }
-          } catch (err) {
-            logger.warn(`autoResolveStaleFailureNodes failed: ${err}`);
-          }
-
-          // User-signal resolution: if a user message reads as "fixed /
-          // works now / 好了", mark the most recent active failure on
-          // the same target as resolved. This is the explicit closing
-          // signal that complements the staleness sweep.
-          if (
-            message.role === "user" &&
-            USER_RESOLVED_PATTERNS.some((re) => re.test(message.content || ""))
-          ) {
-            // Most recent mutation tells us which target the user is
-            // referring to. Without this we'd resolve everything, which
-            // is too aggressive.
-            const recentMutation = extractor.getMostRecentMutation();
-            if (recentMutation) {
-              try {
-                const n = await memoryStore.resolveFailureNodesByTarget({
-                  conversationId: conversation.conversationId,
-                  target: {
-                    filePath: recentMutation.filePath,
-                    command: recentMutation.command,
-                  },
-                  resolution: `user signaled resolution: "${(message.content || "").slice(0, 80)}"`,
-                  evidenceMessageId: insertedMessage.messageId,
-                });
-                if (n > 0) {
-                  logger.debug(`user-resolved ${n} failure node(s)`);
-                }
-              } catch (err) {
-                logger.warn(`resolveFailureNodesByTarget failed: ${err}`);
-              }
-            }
-          }
-
-          // Extract failure if this is an error and write directly as a
-          // memory_node (kind='failure'). Then check whether a prior
-          // failure with the same anchors should be reopened.
-          const failureNodeIds: string[] = [];
-          if (score.tags.includes("error")) {
-            const extracted = extractor.extractFromErrorMessage(
-              message,
-              conversation.conversationId,
-              seq
-            );
-            if (extracted) {
-              logger.debug(
-                `Extracting failure (type=${extracted.type}, file=${extracted.filePath}, cmd=${extracted.command})`
-              );
-              const failureNode = await memoryStore.createFailureNode({
-                conversationId: conversation.conversationId,
-                sessionId: fileSessionId,
-                seq,
-                type: extracted.type,
-                signature: extracted.signature,
-                raw: extracted.raw,
-                location: extracted.location,
-                attemptedFix: extracted.attemptedFix,
-                filePath: extracted.filePath,
-                command: extracted.command,
-                symbol: extracted.symbol,
-                messageId: extracted.messageId,
-                evidenceMessageId: insertedMessage.messageId,
-                weight: 1.0,
-              });
-              failureNodeIds.push(failureNode.nodeId);
-              try {
-                await lifecycleResolver.reopenFailure({
-                  conversationId: conversation.conversationId,
-                  files: extracted.filePath ? [extracted.filePath] : [],
-                  commands: extracted.command ? [extracted.command] : [],
-                  symbols: extracted.symbol ? [extracted.symbol] : [],
-                  signatures: [extracted.signature],
-                  newFailureNodeId: failureNode.nodeId,
-                  evidenceMessageId: insertedMessage.messageId,
-                  reason: `failure recurred: ${extracted.type} ${extracted.signature.slice(0, 80)}`,
-                });
-              } catch (err) {
-                logger.warn(`reopenFailure failed: ${err}`);
-              }
-            }
-          }
-
-          const nowMs = Date.now();
-          if (nowMs - lastStaleMaintenanceAt >= STALE_MAINTENANCE_INTERVAL_MS) {
-            lastStaleMaintenanceAt = nowMs;
-            try {
-              const result = await memoryStore.runStaleMaintenance({ limit: 100 });
-              if (result.staleNodeIds.length > 0) {
-                logger.debug(
-                  `marked ${result.staleNodeIds.length} memory node(s) stale`
-                );
-              }
-            } catch (err) {
-              logger.warn(`memory stale maintenance failed: ${err}`);
-            }
-          }
-
-          try {
-            await fixAttemptTracker.observeToolResults(message, {
-              conversationId: conversation.conversationId,
-              sessionId: fileSessionId,
-              seq,
-              messageId: insertedMessage.messageId,
-              failureNodeIds,
-            });
-          } catch (err) {
-            logger.warn(`fixAttemptTracker.observeToolResults failed: ${err}`);
-          }
-        } catch (error) {
-          logger.error(`Failed to ingest message: ${error}`);
-        }
-      },
+      // Live ingestion only: transcripts already on disk when the daemon
+      // starts are treated as handled, so a restart cannot re-emit their
+      // prefixes as duplicate rows. Gaps are closed with /reimport.
+      seedExistingFilesToEnd: true,
+      onMessage: ingestOne,
     });
 
     logger.info("Daemon running, watching project directory");

--- a/src/hooks/daemon.ts
+++ b/src/hooks/daemon.ts
@@ -779,8 +779,8 @@ async function startDaemon(args: string[]) {
       conversationId: number,
       targetSessionId: string,
       rawFileContent: string
-    ): Promise<{ decision: number; task: number; constraint: number; skipped: boolean }> => {
-      const counts = { decision: 0, task: 0, constraint: 0, skipped: false };
+    ): Promise<{ decision: number; task: number; constraint: number; superseded: number; skipped: boolean }> => {
+      const counts = { decision: 0, task: 0, constraint: 0, superseded: 0, skipped: false };
       // Prose only — user asks, assistant replies, assistant reasoning. Tool
       // calls and results are the bulk of a transcript and hold none of the
       // memory kinds this pass looks for.
@@ -803,10 +803,34 @@ async function startDaemon(args: string[]) {
         return counts;
       }
 
+      // Items arrive in the order they occurred, so a revision always follows
+      // the node it replaces and can resolve to a nodeId that already exists.
+      const nodeIdByStatement = new Map<string, string>();
+      const statementKey = (kind: string, statement: string) =>
+        `${kind}:${statement.toLowerCase().replace(/\s+/g, " ")}`;
+
+      let supersedes = 0;
       for (const item of extracted) {
         try {
+          // A session revises itself. Recording only the final position would
+          // discard how it got there, which is exactly what makes the earlier
+          // decisions worth keeping — so the replaced node is superseded, not
+          // deleted, matching what the live mark path does.
+          let supersedesNodeId: string | undefined;
+          if (item.revises) {
+            supersedesNodeId = nodeIdByStatement.get(
+              statementKey(item.kind, item.revises)
+            );
+            if (!supersedesNodeId) {
+              logger.debug(
+                `[reimport] "${item.statement}" claims to revise an item that was not extracted; storing it standalone`
+              );
+            }
+          }
+
+          let created;
           if (item.kind === "decision") {
-            await memoryStore.createDecisionNode({
+            created = await memoryStore.createDecisionNode({
               conversationId,
               sessionId: targetSessionId,
               decision: item.statement,
@@ -815,30 +839,40 @@ async function startDaemon(args: string[]) {
               content: item.rationale
                 ? `${item.statement}\n\n${item.rationale}`
                 : item.statement,
+              supersedesNodeId,
             });
           } else if (item.kind === "task") {
-            await memoryStore.createTaskNode({
+            created = await memoryStore.createTaskNode({
               conversationId,
               sessionId: targetSessionId,
               task: item.statement,
               details: item.rationale,
+              supersedesNodeId,
             });
           } else {
-            await memoryStore.createConstraintNode({
+            created = await memoryStore.createConstraintNode({
               conversationId,
               sessionId: targetSessionId,
               constraint: item.statement,
               details: item.rationale,
+              supersedesNodeId,
             });
           }
+
+          nodeIdByStatement.set(
+            statementKey(item.kind, item.statement),
+            created.nodeId
+          );
           counts[item.kind]++;
+          if (supersedesNodeId) supersedes++;
         } catch (err) {
           logger.warn(`[reimport] could not store ${item.kind}: ${err}`);
         }
       }
+      counts.superseded = supersedes;
 
       logger.info(
-        `[reimport] recovered ${counts.decision} decision(s), ${counts.task} task(s), ${counts.constraint} constraint(s)`
+        `[reimport] recovered ${counts.decision} decision(s), ${counts.task} task(s), ${counts.constraint} constraint(s); ${counts.superseded} of them supersede an earlier version`
       );
       return counts;
     };
@@ -885,7 +919,7 @@ async function startDaemon(args: string[]) {
       // Deterministic rules have now recovered failures, fix attempts and
       // summaries. Decisions, tasks and constraints are stated in prose and
       // have no rule that produces them, so read them back with the model.
-      let keyMemories = { decision: 0, task: 0, constraint: 0, skipped: false };
+      let keyMemories = { decision: 0, task: 0, constraint: 0, superseded: 0, skipped: false };
       if (rebuilt && !config.compactionDisableLlm) {
         keyMemories = await rebuildKeyMemories(
           rebuilt.conversationId,

--- a/src/hooks/jsonl-watcher.ts
+++ b/src/hooks/jsonl-watcher.ts
@@ -247,6 +247,31 @@ export class CodeMemoryJsonlWatcher {
   /**
    * Read new lines from a JSONL file
    */
+  /**
+   * Resume position for a file, in the same units readNewLines uses.
+   *
+   * The offset map is process-local, so a restart previously rewound every
+   * watched file to 0 and re-emitted its whole prefix. The daemon persists
+   * these values and seeds them back through here.
+   */
+  getOffset(filePath: string): number {
+    return this.watchedFiles.get(filePath) || 0;
+  }
+
+  seedOffset(filePath: string, offset: number): void {
+    this.watchedFiles.set(filePath, Math.max(0, offset));
+  }
+
+  /** Byte-equivalent length of the file as readNewLines measures it. */
+  async currentLength(filePath: string): Promise<number> {
+    try {
+      const content = await readFile(filePath, "utf-8");
+      return content.length;
+    } catch {
+      return 0;
+    }
+  }
+
   async readNewLines(filePath: string): Promise<JsonlMessage[]> {
     const lastOffset = this.watchedFiles.get(filePath) || 0;
     const lines = await this.readFileLines(filePath, lastOffset);

--- a/src/hooks/project-watcher-manager.ts
+++ b/src/hooks/project-watcher-manager.ts
@@ -9,6 +9,7 @@
 
 import { CodeMemoryJsonlWatcher, createJsonlWatcher, FileWatchEvent, JsonlMessage } from "./jsonl-watcher.js";
 import { join } from "node:path";
+import { readdir } from "node:fs/promises";
 
 // Logger interface
 interface SimpleLogger {
@@ -26,6 +27,17 @@ export interface ProjectWatcherOptions {
   sessionId: string;
   pollInterval?: number;
   onMessage?: (message: JsonlMessage, filePath: string) => void;
+
+  /**
+   * Treat transcripts already on disk when the watcher starts as handled,
+   * ingesting only what arrives afterwards.
+   *
+   * The offset map is process-local, so without this a restart rewinds every
+   * file in the project directory to 0 and re-emits its whole prefix. Nothing
+   * dedupes on the way in, so those lines become duplicate rows. Files created
+   * after start are unaffected — they are genuinely new and read from 0.
+   */
+  seedExistingFilesToEnd?: boolean;
 }
 
 export class ProjectWatcher {
@@ -91,6 +103,10 @@ export class ProjectWatcher {
       await this.handleFileUpdate(event.filePath);
     });
 
+    if (this.options.seedExistingFilesToEnd) {
+      await this.seedExistingFiles();
+    }
+
     await this.watcher.start();
     this.isRunning = true;
     this.deps.info(`[ProjectWatcher] Started for ${this.options.projectPath}`);
@@ -104,6 +120,56 @@ export class ProjectWatcher {
     this.watcher.stop();
     this.isRunning = false;
     this.deps.info(`[ProjectWatcher] Stopped for ${this.options.projectPath}`);
+  }
+
+  /**
+   * Mark every transcript present right now as fully read. Done before the
+   * underlying watcher starts, so the initial scan reports no backlog.
+   */
+  /** Directory this watcher observes, so callers can locate a transcript. */
+  get watchDirectory(): string {
+    return this.projectWatchPath;
+  }
+
+  /**
+   * Move the read position to the end of a file. Used after a re-import has
+   * replayed it in full, so the next poll does not re-emit the same lines.
+   */
+  async markFileConsumed(filePath: string): Promise<void> {
+    const length = await this.watcher.currentLength(filePath);
+    this.watcher.seedOffset(filePath, length);
+  }
+
+  /** Full parse of one transcript, used by the re-import path. */
+  async readAllMessages(filePath: string): Promise<JsonlMessage[]> {
+    return this.watcher.readAllLines(filePath);
+  }
+
+  private async seedExistingFiles(): Promise<void> {
+    let entries: string[] = [];
+    try {
+      entries = await readdir(this.projectWatchPath);
+    } catch (error) {
+      this.deps.warn(`[ProjectWatcher] Could not list ${this.projectWatchPath}: ${error}`);
+      return;
+    }
+
+    let seeded = 0;
+    for (const name of entries) {
+      if (!name.endsWith(".jsonl")) continue;
+      const filePath = join(this.projectWatchPath, name);
+      const length = await this.watcher.currentLength(filePath);
+      if (length > 0) {
+        this.watcher.seedOffset(filePath, length);
+        seeded++;
+      }
+    }
+
+    if (seeded > 0) {
+      this.deps.info(
+        `[ProjectWatcher] Treating ${seeded} existing transcript(s) as already ingested; use the re-import command to backfill`
+      );
+    }
   }
 
   private async handleNewFile(filePath: string): Promise<void> {

--- a/src/memory/extract-key-memories.ts
+++ b/src/memory/extract-key-memories.ts
@@ -28,6 +28,13 @@ export interface ExtractedKeyMemory {
   rationale: string;
   /** Only meaningful for decisions. */
   alternativesRejected?: string[];
+  /**
+   * Statement of an earlier item this one replaces, verbatim as it was
+   * reported. A session revises its own decisions, retargets its tasks and
+   * relaxes its constraints; recording only the final state would throw away
+   * the reasoning that got there.
+   */
+  revises?: string;
 }
 
 export interface ExtractKeyMemoriesOptions {
@@ -44,20 +51,23 @@ const DEFAULT_CHUNK_CHARS = 24_000;
 const DEFAULT_MAX_CHUNKS = 20;
 const DEFAULT_TIMEOUT_MS = 60_000;
 
-const PROMPT = `You are reading an excerpt of a software engineering session transcript.
+const PROMPT = `You are reading an excerpt of a software engineering session transcript, in chronological order.
 
-Extract only durable engineering memory of three kinds:
+Extract durable engineering memory of three kinds:
 - "decision": a technical choice that was committed to (schema shape, library, refactor direction, boundary). Include why, and any alternative explicitly rejected.
 - "task": a non-trivial objective the work is pursuing.
 - "constraint": a hard rule the work must respect (compatibility boundary, performance budget, security or compliance requirement, an explicit must-not).
 
+A session changes its mind. When a later statement replaces an earlier one — a decision reversed, a task retargeted, a constraint relaxed or tightened — report BOTH, in the order they occurred, and set "revises" on the later one to the exact "statement" text of the item it replaces. Do not silently drop the earlier version: how the work arrived at its position is part of the record.
+
 Rules:
 - Extract only what the transcript states or clearly commits to. Never infer, generalize, or invent.
-- Skip trivia, exploratory musing, and anything later abandoned in the same excerpt.
+- List items in the order they appear.
+- Skip trivia and exploratory musing that was never committed to.
 - Prefer few high-value items over many weak ones. An excerpt with nothing durable yields an empty list.
 
 Reply with JSON only, no prose and no code fence:
-{"items":[{"kind":"decision|task|constraint","statement":"...","rationale":"...","alternativesRejected":["..."]}]}`;
+{"items":[{"kind":"decision|task|constraint","statement":"...","rationale":"...","alternativesRejected":["..."],"revises":"..."}]}`;
 
 /**
  * Build the text an extraction pass should read, straight from the raw
@@ -131,8 +141,18 @@ export async function extractKeyMemories(
   const collected: ExtractedKeyMemory[] = [];
   for (let i = 0; i < chunks.length; i++) {
     try {
+      // Carry what earlier chunks produced into this one. Without it a
+      // revision can only ever be spotted inside a single excerpt, and a
+      // decision reversed two chunks later reads as an unrelated second
+      // decision.
+      const priorContext =
+        collected.length > 0
+          ? `\n\n--- already extracted from earlier excerpts (set "revises" to one of these statements if this excerpt replaces it) ---\n` +
+            collected.map((m) => `- [${m.kind}] ${m.statement}`).join("\n")
+          : "";
+
       const raw = await runClaude(
-        `${PROMPT}\n\n--- transcript excerpt ${i + 1}/${chunks.length} ---\n${chunks[i]}`,
+        `${PROMPT}${priorContext}\n\n--- transcript excerpt ${i + 1}/${chunks.length} ---\n${chunks[i]}`,
         options
       );
       collected.push(...parseItems(raw));
@@ -195,16 +215,34 @@ function parseItems(raw: string): ExtractedKeyMemory[] {
         alternativesRejected: Array.isArray(item?.alternativesRejected)
           ? item.alternativesRejected.filter((a: unknown) => typeof a === "string")
           : undefined,
+        revises:
+          typeof item?.revises === "string" && item.revises.trim()
+            ? item.revises.trim()
+            : undefined,
       };
     })
     .filter((x: ExtractedKeyMemory | null): x is ExtractedKeyMemory => x !== null);
 }
 
-/** Chunks overlap in subject matter, so the same decision can be reported twice. */
+/**
+ * Collapse only exact restatements — the same item reported twice because
+ * chunks overlap in subject matter.
+ *
+ * An item carrying `revises` is never folded away even if its statement
+ * matches something seen before: it is a distinct point in the session's
+ * history, and dropping it would flatten the revision chain this pass exists
+ * to preserve. Order is preserved throughout, because the rebuild creates
+ * nodes in sequence and each supersede has to land on a node that already
+ * exists.
+ */
 function dedupe(items: ExtractedKeyMemory[]): ExtractedKeyMemory[] {
   const seen = new Set<string>();
   const out: ExtractedKeyMemory[] = [];
   for (const item of items) {
+    if (item.revises) {
+      out.push(item);
+      continue;
+    }
     const key = `${item.kind}:${item.statement.toLowerCase().replace(/\s+/g, " ")}`;
     if (seen.has(key)) continue;
     seen.add(key);

--- a/src/memory/extract-key-memories.ts
+++ b/src/memory/extract-key-memories.ts
@@ -1,0 +1,268 @@
+/**
+ * CodeMemory for Claude Code - Key memory extraction for re-import
+ *
+ * A re-import rebuilds a session from its transcript. The deterministic
+ * extractors recover failures, fix attempts and summaries, because those are
+ * derivable from tool results and errors. Decisions, tasks and constraints are
+ * not: they are stated in prose, and until now the only way they entered the
+ * store was a mark skill the model had to choose to invoke.
+ *
+ * A full-delete re-import would therefore lose them permanently, so this pass
+ * reads them back out of the transcript with an LLM.
+ */
+
+import { spawn } from "node:child_process";
+import {
+  buildClaudeCliArgs,
+  claudeCliSpawnEnv,
+  describeClaudeCliFailure,
+} from "../llm/claude-cli.js";
+
+export type KeyMemoryKind = "decision" | "task" | "constraint";
+
+export interface ExtractedKeyMemory {
+  kind: KeyMemoryKind;
+  /** One-line statement of the decision / task / constraint. */
+  statement: string;
+  /** Why it was made or why it holds; empty when the transcript does not say. */
+  rationale: string;
+  /** Only meaningful for decisions. */
+  alternativesRejected?: string[];
+}
+
+export interface ExtractKeyMemoriesOptions {
+  model?: string;
+  timeoutMs?: number;
+  /** Characters of transcript per LLM call. */
+  chunkChars?: number;
+  /** Upper bound on calls, so a huge transcript cannot run unbounded. */
+  maxChunks?: number;
+  log?: { info: (m: string) => void; warn: (m: string) => void };
+}
+
+const DEFAULT_CHUNK_CHARS = 24_000;
+const DEFAULT_MAX_CHUNKS = 20;
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+const PROMPT = `You are reading an excerpt of a software engineering session transcript.
+
+Extract only durable engineering memory of three kinds:
+- "decision": a technical choice that was committed to (schema shape, library, refactor direction, boundary). Include why, and any alternative explicitly rejected.
+- "task": a non-trivial objective the work is pursuing.
+- "constraint": a hard rule the work must respect (compatibility boundary, performance budget, security or compliance requirement, an explicit must-not).
+
+Rules:
+- Extract only what the transcript states or clearly commits to. Never infer, generalize, or invent.
+- Skip trivia, exploratory musing, and anything later abandoned in the same excerpt.
+- Prefer few high-value items over many weak ones. An excerpt with nothing durable yields an empty list.
+
+Reply with JSON only, no prose and no code fence:
+{"items":[{"kind":"decision|task|constraint","statement":"...","rationale":"...","alternativesRejected":["..."]}]}`;
+
+/**
+ * Build the text an extraction pass should read, straight from the raw
+ * transcript.
+ *
+ * Only prose carries decisions, tasks and constraints: what the user asked
+ * for, what the assistant said, and what it reasoned about. Tool calls and
+ * tool results are the bulk of a transcript — 682 of 1096 content parts in a
+ * real session here — and contain none of it, so feeding them to the model
+ * costs tokens and dilutes the signal.
+ *
+ * This reads the file directly rather than reusing the ingest parser, for two
+ * reasons: that parser drops `thinking` blocks entirely (221 of them in the
+ * same session), and it renders tool calls into the flattened content string,
+ * which would be the opposite of what is wanted here.
+ */
+export function buildExtractionTranscript(rawFileContent: string): string {
+  const out: string[] = [];
+
+  for (const line of rawFileContent.split("\n")) {
+    if (!line.trim()) continue;
+
+    let entry: any;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const role = entry?.message?.role ?? entry?.type;
+    if (role !== "user" && role !== "assistant") continue;
+    // Subagent chatter is not this session's engineering record.
+    if (entry?.isSidechain) continue;
+
+    const content = entry?.message?.content;
+    const segments: string[] = [];
+
+    if (typeof content === "string") {
+      segments.push(content);
+    } else if (Array.isArray(content)) {
+      for (const part of content) {
+        if (part?.type === "text" && typeof part.text === "string") {
+          segments.push(part.text);
+        } else if (part?.type === "thinking" && typeof part.thinking === "string") {
+          segments.push(`(reasoning) ${part.thinking}`);
+        }
+        // tool_use and tool_result are intentionally skipped.
+      }
+    }
+
+    const text = segments.join("\n").trim();
+    if (text) out.push(`[${role.toUpperCase()}] ${text}`);
+  }
+
+  return out.join("\n\n");
+}
+
+export async function extractKeyMemories(
+  transcript: string,
+  options: ExtractKeyMemoriesOptions = {}
+): Promise<ExtractedKeyMemory[]> {
+  const chunkChars = options.chunkChars ?? DEFAULT_CHUNK_CHARS;
+  const maxChunks = options.maxChunks ?? DEFAULT_MAX_CHUNKS;
+  const chunks = chunkTranscript(transcript, chunkChars).slice(0, maxChunks);
+
+  if (chunks.length === 0) return [];
+  options.log?.info(
+    `[reimport] extracting key memories from ${chunks.length} chunk(s)`
+  );
+
+  const collected: ExtractedKeyMemory[] = [];
+  for (let i = 0; i < chunks.length; i++) {
+    try {
+      const raw = await runClaude(
+        `${PROMPT}\n\n--- transcript excerpt ${i + 1}/${chunks.length} ---\n${chunks[i]}`,
+        options
+      );
+      collected.push(...parseItems(raw));
+    } catch (error) {
+      // One bad chunk must not discard the rest: a partial rebuild of these
+      // nodes is better than none, and the failure is visible in the log.
+      options.log?.warn(
+        `[reimport] key-memory extraction failed on chunk ${i + 1}/${chunks.length}: ${error}`
+      );
+    }
+  }
+
+  return dedupe(collected);
+}
+
+/** Split on line boundaries so a record is never cut mid-way. */
+function chunkTranscript(transcript: string, chunkChars: number): string[] {
+  const lines = transcript.split("\n").filter((l) => l.trim());
+  const chunks: string[] = [];
+  let current: string[] = [];
+  let size = 0;
+
+  for (const line of lines) {
+    if (size + line.length > chunkChars && current.length > 0) {
+      chunks.push(current.join("\n"));
+      current = [];
+      size = 0;
+    }
+    current.push(line);
+    size += line.length + 1;
+  }
+  if (current.length > 0) chunks.push(current.join("\n"));
+  return chunks;
+}
+
+function parseItems(raw: string): ExtractedKeyMemory[] {
+  const text = raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/```\s*$/, "");
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end <= start) return [];
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(text.slice(start, end + 1));
+  } catch {
+    return [];
+  }
+
+  const items = Array.isArray(parsed?.items) ? parsed.items : [];
+  return items
+    .map((item: any): ExtractedKeyMemory | null => {
+      const kind = item?.kind;
+      const statement = typeof item?.statement === "string" ? item.statement.trim() : "";
+      if (kind !== "decision" && kind !== "task" && kind !== "constraint") return null;
+      if (!statement) return null;
+      return {
+        kind,
+        statement,
+        rationale: typeof item?.rationale === "string" ? item.rationale.trim() : "",
+        alternativesRejected: Array.isArray(item?.alternativesRejected)
+          ? item.alternativesRejected.filter((a: unknown) => typeof a === "string")
+          : undefined,
+      };
+    })
+    .filter((x: ExtractedKeyMemory | null): x is ExtractedKeyMemory => x !== null);
+}
+
+/** Chunks overlap in subject matter, so the same decision can be reported twice. */
+function dedupe(items: ExtractedKeyMemory[]): ExtractedKeyMemory[] {
+  const seen = new Set<string>();
+  const out: ExtractedKeyMemory[] = [];
+  for (const item of items) {
+    const key = `${item.kind}:${item.statement.toLowerCase().replace(/\s+/g, " ")}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+function runClaude(
+  prompt: string,
+  options: ExtractKeyMemoriesOptions
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("claude", buildClaudeCliArgs(options.model), {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: claudeCliSpawnEnv(),
+    });
+
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGTERM");
+      reject(new Error(`timed out after ${options.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms`));
+    }, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+    child.stdout.on("data", (c: Buffer) => stdout.push(c));
+    child.stderr.on("data", (c: Buffer) => stderr.push(c));
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(
+          new Error(
+            `claude --print exited with code ${code}: ${describeClaudeCliFailure(
+              Buffer.concat(stdout).toString("utf-8"),
+              Buffer.concat(stderr).toString("utf-8")
+            )}`
+          )
+        );
+        return;
+      }
+      resolve(Buffer.concat(stdout).toString("utf-8").trim());
+    });
+
+    child.stdin.write(prompt);
+    child.stdin.end();
+  });
+}


### PR DESCRIPTION
Restarts were duplicating stored conversations. This replaces the implicit startup backfill with live-only ingestion, and adds a command to rebuild a session deliberately when a gap needs closing.

---

## The bug

The offset map tracking how far each transcript has been consumed lives in **process memory**. A restart rewound every file in the project directory to 0 and re-emitted its entire prefix.

Nothing dedupes on the way in. `conversation_messages.messageId` is an `AUTOINCREMENT` primary key with no relationship to the jsonl uuid, and no uniqueness constraint binds a row to its source line.

Measured against a static 10-line transcript that never changed between runs:

| | rows in `conversation_messages` |
|---|---|
| after 1st start | 10 |
| after 2nd start | **20** |
| after 3rd start | **30** |

The watcher observes a *directory*, not one file, so the multiplier is however many transcripts are in it. One project directory here holds **204**.

> `project-watcher-manager.ts` already carried a comment about "the entire prefix of the file being ingested twice" — the in-process case was known and solved with the offset map. It was never extended across restarts.

## 1. Live-only ingestion

`seedExistingFilesToEnd` marks every transcript present when the watcher starts as fully read, before the initial scan. Files created later are untouched — they are genuinely new and still read from 0.

What this gives up is deliberate: a session that ran while the daemon was down is never picked up on its own. That becomes an explicit action rather than something guessed at on every boot.

| | before | after |
|---|---|---|
| startup, transcript already present | re-ingests all of it | 0 rows |
| append while running | ingested | ingested |
| restart | **duplicates** | unchanged |

## 2. `/codememory-reimport`

Rebuilds one session by deleting everything it owns and replaying its transcript. **Deleting first is what makes it idempotent** — running it twice leaves exactly what running it once leaves.

The delete is total, including memory nodes. A partial one would leave summary nodes pointing at `summaryId`s that no longer exist, and would let the failure and fix_attempt extractors re-derive rows already present.

**Phase 1 — deterministic replay.** The 209-line ingest closure is hoisted out of the `startProjectWatcher` call into `ingestOne` **with no change to its body**, so the live path and the rebuild path cannot drift apart. Failures, fix attempts and summaries come back exactly as they were captured live.

**Phase 2 — key-memory extraction.** Decisions, tasks and constraints are stated in prose and no rule produces them; the only way they ever entered the store was a mark skill the model had to choose to invoke. A total delete would lose them permanently, so an LLM pass reads them back out.

### Extraction reads prose only

Tool calls and results are the bulk of a transcript and hold none of these memory kinds, so they are never sent to the model. On a real 3.7 MB session:

| | characters | chunks |
|---|---|---|
| full transcript | 3,746,396 | 157 |
| prose only | **81,520** | **4** |
| | **−97.8%** | |

This is not only a cost saving. At 157 chunks the pass would have hit the 20-chunk ceiling and silently extracted **the first 13% of the session**.

It reads the raw jsonl rather than reusing `parseRawLine`, which drops `thinking` blocks entirely (221 of them in that session) and renders tool calls into the flattened content string — the opposite of what is wanted here. Capturing thinking in the *live* ingest path is a separate decision, since it would change tiering and storage volume; not done here.

Extraction is skipped, and says so, when `CODEMEMORY_COMPACTION_DISABLE_LLM` is set. A failed chunk is logged and the rest continue — a session rebuilt without some of its decisions beats a re-import that aborts halfway.

## Revisions are part of the record

A session revises itself — a decision reversed once its cost is understood, a constraint relaxed because the work found it too strict. The live path already models this: `supersedesNodeId` marks the old node superseded and records the edge rather than deleting it. The first version of this extraction threw that away three times over.

The prompt said *"skip anything later abandoned in the same excerpt"* — it actively instructed the model to discard the earlier version. Each chunk was extracted in isolation, so a revision was only visible when both versions landed in the same excerpt. And `dedupe()` collapsed on kind + statement globally, flattening a chain into whichever version it saw first.

Now the model reports both versions in order with a `revises` field, already-extracted items are carried into later chunk prompts as context, and items carrying `revises` are never folded. The rebuild resolves `revises` to a real `supersedesNodeId`, taking the same explicit path the mark skills take — more accurate than the auto-supersede judge, which only sees stored node content while the extractor saw the transcript.

Verified against a transcript with two deliberate revision chains:

```
decision   [superseded]  Add sourceUuid field + global unique index
decision   [active]      Clear session on reimport, then reingest      ←supersedes←
constraint [superseded]  User data must never be deleted
constraint [active]      Reimport may delete its own session's data    ←supersedes←
task       [active]      Enable deduplication for conversation_messages
```

Two `supersedes` edges and two `active -> superseded` lifecycle events typed `supersede_decision` / `supersede_constraint`. The earlier versions are retained as superseded, not dropped.

## Verification

- **290/290 tests pass**; `plugin:release-check` passes with `dist/` committed
- Hoisting `ingestOne` is behavior-neutral — the full suite passes with the body unchanged
- Restart behavior: 0 → append 3 → 3 → restart → still 3
- Re-import idempotency: two consecutive runs both leave 8 rows
- End to end **through the hook script**, on a transcript seeded with a long `tool_result` payload:

```json
{"linesParsed":4,"messagesStored":4,
 "keyMemories":{"decision":1,"task":1,"constraint":1,"skipped":false}}
```

Input to the model was 320 characters of prose out of a 1,197-character transcript — no tool payload reached it — and the recovered decision cites reasoning that exists **only** inside a `thinking` block, which the ingest parser would have discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)