### PR TITLE
release: 0.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codememory-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CodeMemory plugin for Claude Code CLI. Replaces traditional sliding-window conversation compaction with a DAG-based summarization system that preserves every message while maintaining active context within model token limits.",
   "author": {
     "name": "harry"

--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ The mark skills post through `hooks/scripts/codememory-mark.sh`, and the daemon 
 
 ### Slash commands
 
-`/codememory-status`, `/codememory-grep`, `/codememory-describe`, `/codememory-expand`, `/codememory-expand-query`, `/codememory-watch`
+`/codememory-status`, `/codememory-grep`, `/codememory-describe`, `/codememory-expand`, `/codememory-expand-query`, `/codememory-watch`, `/codememory-reimport`
+
+`/codememory-reimport` rebuilds one session from its transcript on disk. The daemon ingests **live only** — transcripts already present when it starts are treated as handled, so a restart never re-reads them and cannot duplicate rows. The gap that leaves is deliberate: a session that ran while the daemon was down is closed with this command rather than guessed at on every boot. It deletes the session's stored data before replaying, which is what makes running it twice equivalent to running it once.
 
 ## Documentation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -165,7 +165,9 @@ Mark 类 Skill 会通过 `hooks/scripts/codememory-mark.sh` 发送请求，而 d
 
 ### Slash 命令
 
-`/codememory-status`、`/codememory-grep`、`/codememory-describe`、`/codememory-expand`、`/codememory-expand-query`、`/codememory-watch`
+`/codememory-status`、`/codememory-grep`、`/codememory-describe`、`/codememory-expand`、`/codememory-expand-query`、`/codememory-watch`、`/codememory-reimport`
+
+`/codememory-reimport` 从磁盘上的 transcript 重建单个会话。daemon **只做实时摄入** —— 启动时已存在的 transcript 一律视为已处理，所以重启不会重读、也就不会产生重复行。由此留下的缺口是有意的：daemon 停机期间跑过的会话，用这条命令显式补齐，而不是每次启动都去猜。它会先删除该会话已存的数据再重放，这正是"跑两次等同于跑一次"的原因。
 
 ## 文档
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codememory-for-claude",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CodeMemory for Claude Code CLI",
   "type": "module",
   "main": "dist/plugin/index.js",


### PR DESCRIPTION
Version bump and docs. All the code shipped in #7.

`0.3.0` rather than `0.2.1`: **ingestion changed behavior in a way installed copies will notice.** The daemon no longer reads transcripts already on disk when it starts. A restart stops re-ingesting history — and stops silently picking up a session that ran while it was down.

## Why that trade

The offset map tracking how far each transcript had been read lived in process memory, so every restart rewound each file to 0 and re-emitted its prefix. Nothing dedupes on the way in: `conversation_messages.messageId` is an `AUTOINCREMENT` key with no relationship to the jsonl uuid.

Measured against a static 10-line transcript that never changed:

| | rows |
|---|---|
| after 1st start | 10 |
| after 2nd start | **20** |
| after 3rd start | **30** |

The watcher observes a *directory*, so the multiplier is however many transcripts are in it. One project directory here holds **204**.

## What closes the gap

`/codememory-reimport` rebuilds one session from its transcript. It deletes the session's stored data first — which is what makes running it twice equivalent to running it once — then replays every line through the same ingest path the watcher uses, so the live and rebuild paths cannot drift apart.

A second pass recovers the memory kinds no deterministic rule produces: decisions, tasks and constraints. It reads **prose only**, because tool calls and results hold none of them and are the bulk of a transcript:

| | characters | chunks |
|---|---|---|
| full transcript | 3,746,396 | 157 |
| prose only | **81,520** | **4** |

Unfiltered, that pass would have hit the 20-chunk ceiling and extracted the first 13% of the session.

**Revisions survive the rebuild.** A decision reversed later in the session is stored as two nodes with a `supersedes` edge and an `active -> superseded` lifecycle event — the same records the live mark path writes — rather than being flattened to whichever version came last.

## Docs

Both READMEs now list `/codememory-reimport` and explain why startup does no backfill, so the behavior change is documented where users will look for it.

## Release checklist

- [x] `dist/` rebuilt — `npm run build` produces no diff
- [x] `290/290` tests pass
- [x] `claude plugin validate .` passes
- [x] `package.json` and `.claude-plugin/plugin.json` agree on `0.3.0`

After merge I'll run `claude plugin tag . --push` to create `codememory-plugin--v0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)