### PR TITLE
feat: make the prior-failure path observable

### DIFF
--- a/dist/db/connection.js
+++ b/dist/db/connection.js
@@ -461,6 +461,58 @@ export async function runCodeMemoryMigrations(db) {
       ON memory_nodes(sourceToolUseId)
       WHERE sourceToolUseId IS NOT NULL
   `);
+    // Migration 26: Prior-failure lookup telemetry. The PreToolUse path is the
+    // product's headline behavior and was entirely unobservable: markUsed was
+    // never called from it, so useCount stayed 0 across every failure node and
+    // the database could not say whether a warning had ever fired. Worse, a
+    // silent lookup has four different causes — no target, no candidate, below
+    // the confidence floor, debounced — and they demand opposite fixes.
+    //
+    // A row per lookup, including the ones that surfaced nothing, is what makes
+    // recall measurable and lets an injection be joined against whatever failed
+    // afterwards.
+    await db.exec(`
+    CREATE TABLE IF NOT EXISTS failure_lookup_events (
+      eventId INTEGER PRIMARY KEY AUTOINCREMENT,
+      conversationId INTEGER,
+      sessionId TEXT,
+      toolName TEXT NOT NULL,
+      targetFile TEXT,
+      targetCommand TEXT,
+      targetFileTag TEXT,
+      targetCommandTag TEXT,
+      outcome TEXT NOT NULL CHECK(outcome IN (
+        'injected', 'debounced', 'below_confidence', 'no_candidates', 'no_target'
+      )),
+      candidateCount INTEGER NOT NULL DEFAULT 0,
+      passedCount INTEGER NOT NULL DEFAULT 0,
+      topScore REAL,
+      surfacedNodeIds TEXT,
+      source TEXT NOT NULL DEFAULT 'daemon',
+      createdAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+    await db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_failure_lookup_events_outcome ON failure_lookup_events(
+      outcome, createdAt
+    )
+  `);
+    // The joinable columns were added after the table shipped in a working
+    // branch, so upgrade in place rather than assuming a fresh database.
+    await addColumnIfMissing(db, "failure_lookup_events", "targetFileTag", "TEXT");
+    await addColumnIfMissing(db, "failure_lookup_events", "targetCommandTag", "TEXT");
+    // Indexed on the normalized forms: joining telemetry to memory_tags is the
+    // whole reason these columns exist, and the raw path cannot serve for it.
+    await db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_failure_lookup_events_target ON failure_lookup_events(
+      targetFileTag, createdAt
+    )
+  `);
+    await db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_failure_lookup_events_command ON failure_lookup_events(
+      targetCommandTag, createdAt
+    )
+  `);
     console.log(`[codememory] Database migrations completed successfully`);
 }
 /**

--- a/dist/failure-lookup-cli.js
+++ b/dist/failure-lookup-cli.js
@@ -31,6 +31,31 @@ async function main() {
         const memoryStore = createMemoryNodeStore(db);
         const toolInput = parseInputArg(rawToolInput);
         const response = await lookupForPreToolUse(memoryStore, toolName, toolInput);
+        // The cold path runs whenever the daemon is down, so leaving it
+        // uninstrumented would make recall look worse than it is exactly when the
+        // system is already degraded. Telemetry never blocks the tool call.
+        try {
+            await memoryStore.recordFailureLookup({
+                sessionId,
+                toolName,
+                targetFile: response.diagnostics.targetFile,
+                targetCommand: response.diagnostics.targetCommand,
+                targetFileTag: response.diagnostics.targetFileTag,
+                targetCommandTag: response.diagnostics.targetCommandTag,
+                outcome: response.diagnostics.outcome,
+                candidateCount: response.diagnostics.candidateCount,
+                passedCount: response.diagnostics.passedCount,
+                topScore: response.diagnostics.topScore,
+                surfacedNodeIds: response.diagnostics.surfacedNodeIds,
+                source: "cli",
+            });
+            if (response.shouldInject) {
+                await memoryStore.markUsed(response.diagnostics.surfacedNodeIds);
+            }
+        }
+        catch {
+            // Measurement gap, not a user-visible failure.
+        }
         console.log(JSON.stringify(response));
     }
     catch (err) {

--- a/dist/failure-lookup.js
+++ b/dist/failure-lookup.js
@@ -8,6 +8,7 @@
  * gets the same signal-to-noise as before — see #19 for why low-confidence
  * matches must be filtered before injection.
  */
+import { qualifyFileTag, commandVariants } from "./retrieval-plan.js";
 const MIN_CONFIDENCE = 0.6;
 const DECAY_HALF_LIFE_DAYS = 30;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -112,6 +113,12 @@ export async function lookupForPreToolUse(store, toolName, toolInput, options = 
             shouldInject: false,
             reason: "No retrievable target from tool input",
             failures: [],
+            diagnostics: {
+                outcome: "no_target",
+                candidateCount: 0,
+                passedCount: 0,
+                surfacedNodeIds: [],
+            },
         };
     }
     const candidates = await store.findFailuresByAnchors({
@@ -121,11 +128,24 @@ export async function lookupForPreToolUse(store, toolName, toolInput, options = 
         limit: 8,
     });
     const now = Date.now();
-    const scored = candidates
+    // Score everything first: the highest score among *rejected* candidates is
+    // the number that says whether the floor is the thing suppressing recall.
+    const allScored = candidates
         .map(({ node }) => ({ node, score: scoreMatch(node, targets, now) }))
-        .filter(({ score }) => score >= MIN_CONFIDENCE)
-        .sort((a, b) => b.score - a.score)
-        .slice(0, options.limit ?? 2);
+        .sort((a, b) => b.score - a.score);
+    const passed = allScored.filter(({ score }) => score >= MIN_CONFIDENCE);
+    const scored = passed.slice(0, options.limit ?? 2);
+    const baseDiagnostics = {
+        targetFile: targets.filePath,
+        targetCommand: targets.command,
+        targetFileTag: targets.filePath ? qualifyFileTag(targets.filePath) : undefined,
+        targetCommandTag: targets.command
+            ? commandVariants(targets.command).slice(-1)[0]
+            : undefined,
+        candidateCount: candidates.length,
+        passedCount: passed.length,
+        topScore: allScored[0]?.score,
+    };
     if (scored.length === 0) {
         return {
             shouldInject: false,
@@ -133,6 +153,11 @@ export async function lookupForPreToolUse(store, toolName, toolInput, options = 
                 ? `Filtered ${candidates.length} candidate(s) below confidence threshold`
                 : "No prior failures for this target",
             failures: [],
+            diagnostics: {
+                ...baseDiagnostics,
+                outcome: candidates.length > 0 ? "below_confidence" : "no_candidates",
+                surfacedNodeIds: [],
+            },
         };
     }
     const failures = scored.map((s) => shapeFailure(s.node, s.score));
@@ -141,6 +166,11 @@ export async function lookupForPreToolUse(store, toolName, toolInput, options = 
         reason: "Found relevant prior failures",
         failures,
         markdown: renderFailureMarkdown(failures),
+        diagnostics: {
+            ...baseDiagnostics,
+            outcome: "injected",
+            surfacedNodeIds: scored.map((s) => s.node.nodeId),
+        },
     };
 }
 function formatAge(createdAt) {

--- a/dist/hooks/daemon.js
+++ b/dist/hooks/daemon.js
@@ -139,6 +139,36 @@ async function startDaemon(args) {
                 /* ignore */
             }
         }
+        /**
+         * Telemetry must never be able to break a tool call, so every failure here
+         * is swallowed. A missing row is a gap in measurement; a thrown error
+         * would be a blocked Edit.
+         */
+        const recordLookup = async (body, response, outcome, surfacedNodeIds) => {
+            try {
+                const conv = await conversationStore.getConversationForSession({
+                    sessionId,
+                });
+                await memoryStore.recordFailureLookup({
+                    conversationId: conv?.conversationId ?? null,
+                    sessionId,
+                    toolName: String(body?.toolName ?? "unknown"),
+                    targetFile: response.diagnostics.targetFile,
+                    targetCommand: response.diagnostics.targetCommand,
+                    targetFileTag: response.diagnostics.targetFileTag,
+                    targetCommandTag: response.diagnostics.targetCommandTag,
+                    outcome,
+                    candidateCount: response.diagnostics.candidateCount,
+                    passedCount: response.diagnostics.passedCount,
+                    topScore: response.diagnostics.topScore,
+                    surfacedNodeIds,
+                    source: "daemon",
+                });
+            }
+            catch (err) {
+                logger.warn(`recordFailureLookup failed: ${err}`);
+            }
+        };
         const lookupServer = http.createServer((req, res) => {
             if (req.method !== "POST") {
                 res.statusCode = 404;
@@ -347,6 +377,7 @@ async function startDaemon(args) {
                             return last != null && now - last < WARN_DEBOUNCE_MS;
                         });
                         if (allRecent) {
+                            await recordLookup(body, response, "debounced", keys);
                             res.setHeader("content-type", "application/json");
                             res.end(JSON.stringify({
                                 shouldInject: false,
@@ -357,7 +388,16 @@ async function startDaemon(args) {
                         }
                         for (const k of keys)
                             recentlyWarned.set(k, now);
+                        // "Used" means actually surfaced to the model, so it is recorded
+                        // here rather than at lookup time — a debounced hit is not a use.
+                        try {
+                            await memoryStore.markUsed(keys);
+                        }
+                        catch (err) {
+                            logger.warn(`markUsed failed: ${err}`);
+                        }
                     }
+                    await recordLookup(body, response, response.diagnostics.outcome, response.diagnostics.surfacedNodeIds);
                     res.setHeader("content-type", "application/json");
                     res.end(JSON.stringify(response));
                 }

--- a/dist/store/memory-store.js
+++ b/dist/store/memory-store.js
@@ -604,6 +604,38 @@ export class MemoryNodeStore {
         })
             .slice(0, input.limit ?? plan.recallPolicy.maxCandidates);
     }
+    /**
+     * Append one row per PreToolUse lookup, including the ones that surfaced
+     * nothing. The silent outcomes are the interesting ones: they separate
+     * "there was no prior failure to warn about" from "there was, and something
+     * suppressed it", which is the difference between a recall problem and a
+     * threshold problem.
+     */
+    async recordFailureLookup(input) {
+        await this.db.run(`INSERT INTO failure_lookup_events (
+         conversationId, sessionId, toolName, targetFile, targetCommand,
+         targetFileTag, targetCommandTag,
+         outcome, candidateCount, passedCount, topScore, surfacedNodeIds,
+         source, createdAt
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, [
+            input.conversationId ?? null,
+            input.sessionId ?? null,
+            input.toolName,
+            input.targetFile ?? null,
+            input.targetCommand ?? null,
+            input.targetFileTag ?? null,
+            input.targetCommandTag ?? null,
+            input.outcome,
+            input.candidateCount,
+            input.passedCount,
+            input.topScore ?? null,
+            input.surfacedNodeIds?.length
+                ? JSON.stringify(input.surfacedNodeIds)
+                : null,
+            input.source ?? "daemon",
+            new Date().toISOString(),
+        ]);
+    }
     async markUsed(nodeIds) {
         if (nodeIds.length === 0)
             return;

--- a/scripts/analyze-failure-recall.mjs
+++ b/scripts/analyze-failure-recall.mjs
@@ -1,0 +1,189 @@
+/**
+ * Retrospective baseline for the prior-failure path.
+ *
+ * The PreToolUse hot path never calls markUsed, so useCount is 0 for every
+ * failure node and the database cannot say whether a warning has ever fired.
+ * This reconstructs the answer without instrumentation: for each failure that
+ * was captured, replay its own anchors through the real lookup and ask whether
+ * an *earlier* failure would have been surfaced before it happened.
+ *
+ * Uses the shipped findFailuresByAnchors and scoreMatch rather than a
+ * reimplementation, so the numbers describe the system as built.
+ */
+
+import { createCodeMemoryDatabaseConnection } from "../dist/db/connection.js";
+import { createMemoryNodeStore } from "../dist/store/memory-store.js";
+import { scoreMatch, FAILURE_LOOKUP_MIN_CONFIDENCE } from "../dist/failure-lookup.js";
+
+const dbPath = process.env.CODEMEMORY_DATABASE_PATH
+  || `${process.env.HOME}/.claude/codememory.db`;
+
+const db = await createCodeMemoryDatabaseConnection(dbPath);
+const store = createMemoryNodeStore(db, {});
+
+const failures = await db.all(
+  `SELECT nodeId, conversationId, content, metadata, createdAt, status, useCount
+     FROM memory_nodes WHERE kind = 'failure' ORDER BY createdAt ASC`
+);
+
+const tagsFor = async (nodeId) =>
+  db.all(`SELECT tagType, tagValue FROM memory_tags WHERE nodeId = ?`, nodeId);
+
+const pct = (n, d) => (d === 0 ? "n/a" : `${((n / d) * 100).toFixed(1)}%`);
+const line = (label, value) => console.log(`  ${label.padEnd(38)} ${value}`);
+
+console.log(`\n数据库: ${dbPath}`);
+console.log(`失败节点: ${failures.length}\n`);
+
+// ---- 1. anchor 覆盖率 -----------------------------------------------------
+console.log("① Anchor 覆盖率  —— 没有 anchor 的失败永远不可能被召回");
+const anchorCounts = { file: 0, command: 0, symbol: 0, signature: 0 };
+const perNode = new Map();
+let noAnchor = 0;
+for (const f of failures) {
+  const tags = await tagsFor(f.nodeId);
+  const byType = {};
+  for (const t of tags) (byType[t.tagType] ??= []).push(t.tagValue);
+  perNode.set(f.nodeId, byType);
+  for (const k of Object.keys(anchorCounts)) if (byType[k]?.length) anchorCounts[k]++;
+  if (!byType.file?.length && !byType.command?.length && !byType.symbol?.length) noAnchor++;
+}
+for (const [k, v] of Object.entries(anchorCounts)) {
+  line(`带 ${k} tag 的节点`, `${v}/${failures.length}  ${pct(v, failures.length)}`);
+}
+line("无任何 file/command/symbol anchor", `${noAnchor}  ${pct(noAnchor, failures.length)}`);
+
+// ---- 2. signature 泛化性 --------------------------------------------------
+console.log("\n② Signature 泛化性  —— 过长 = 掺进了一次性上下文，永远匹配不上");
+const sigLens = [];
+for (const [, byType] of perNode) for (const s of byType.signature ?? []) sigLens.push(s.length);
+sigLens.sort((a, b) => a - b);
+if (sigLens.length) {
+  const at = (p) => sigLens[Math.min(sigLens.length - 1, Math.floor(sigLens.length * p))];
+  line("signature 数量", sigLens.length);
+  line("长度 中位数 / p90 / 最大", `${at(0.5)} / ${at(0.9)} / ${sigLens[sigLens.length - 1]}`);
+  const short = sigLens.filter((l) => l <= 120).length;
+  line("≤120 字符（可复用指纹）", `${short}  ${pct(short, sigLens.length)}`);
+}
+
+// ---- 3. 回溯召回模拟 ------------------------------------------------------
+console.log("\n③ 回溯召回  —— 每个失败发生时，之前的失败会不会被拦下来");
+let wouldWarn = 0, hadEarlierCandidate = 0, belowThreshold = 0;
+const now = Date.now();
+for (let i = 0; i < failures.length; i++) {
+  const f = failures[i];
+  const byType = perNode.get(f.nodeId) ?? {};
+  const candidates = await store.findFailuresByAnchors({
+    files: byType.file, commands: byType.command,
+    symbols: byType.symbol, signatures: byType.signature,
+    limit: 20,
+  });
+  // 只保留严格早于当前失败的节点：模拟"当时"的库状态
+  const earlier = candidates.filter(
+    (c) => c.node.nodeId !== f.nodeId && c.node.createdAt < f.createdAt
+  );
+  if (earlier.length === 0) continue;
+  hadEarlierCandidate++;
+  // scoreMatch compares the stored node against the target being touched, so
+  // replay this failure's own file/command as if a tool were about to run it.
+  const meta = (() => { try { return JSON.parse(f.metadata || "{}"); } catch { return {}; } })();
+  const targets = {
+    filePath: meta.filePath ?? byType.file?.[0],
+    command: meta.command ?? byType.command?.[0],
+  };
+  const at = new Date(f.createdAt).getTime() || now;
+  const passing = earlier.filter(
+    (c) => scoreMatch(c.node, targets, at) >= FAILURE_LOOKUP_MIN_CONFIDENCE
+  );
+  if (passing.length > 0) wouldWarn++; else belowThreshold++;
+}
+line("有更早的同 anchor 候选", `${hadEarlierCandidate}/${failures.length}  ${pct(hadEarlierCandidate, failures.length)}`);
+line("其中会真正触发警告", `${wouldWarn}  ${pct(wouldWarn, hadEarlierCandidate)}`);
+line("被置信度阈值挡下", `${belowThreshold}`);
+line("阈值", FAILURE_LOOKUP_MIN_CONFIDENCE);
+
+// ---- 4. 复发 --------------------------------------------------------------
+console.log("\n④ 复发  —— 记忆本该阻止的事");
+const reopen = await db.get(
+  `SELECT COUNT(*) n FROM memory_lifecycle_events WHERE eventType = 'reopen_failure'`
+);
+const dupSig = await db.all(
+  `SELECT t.tagValue, COUNT(DISTINCT n.nodeId) c FROM memory_tags t
+     JOIN memory_nodes n ON n.nodeId = t.nodeId
+    WHERE t.tagType='signature' AND n.kind='failure'
+    GROUP BY t.tagValue HAVING c > 1`
+);
+line("reopen_failure 事件", reopen?.n ?? 0);
+line("出现 >1 次的 signature", dupSig.length);
+line("failure 节点累计被检索命中", failures.reduce((s, f) => s + (f.useCount || 0), 0));
+
+// ---- 5. 实测埋点 ----------------------------------------------------------
+const hasEvents = await db.get(
+  `SELECT name FROM sqlite_master WHERE type='table' AND name='failure_lookup_events'`
+);
+if (hasEvents) {
+  const rows = await db.all(
+    `SELECT outcome, COUNT(*) n FROM failure_lookup_events GROUP BY outcome ORDER BY n DESC`
+  );
+  const total = rows.reduce((s, r) => s + r.n, 0);
+  console.log("\n⑤ 实测查找结果  —— 埋点上线后才有数据");
+  if (total === 0) {
+    line("记录数", "0（埋点已就绪，尚未产生数据）");
+  } else {
+    for (const r of rows) line(r.outcome, `${r.n}  ${pct(r.n, total)}`);
+    const injected = rows.find((r) => r.outcome === "injected")?.n ?? 0;
+    const hadSomething = rows
+      .filter((r) => r.outcome !== "no_target" && r.outcome !== "no_candidates")
+      .reduce((s, r) => s + r.n, 0);
+    line("注入率（占全部查找）", pct(injected, total));
+    if (hadSomething > 0) {
+      line("有候选时的注入率", pct(injected, hadSomething));
+    }
+    const supp = await db.get(
+      `SELECT COUNT(*) n, MAX(topScore) best FROM failure_lookup_events
+        WHERE outcome = 'below_confidence'`
+    );
+    if (supp?.n) {
+      line("被阈值挡下时的最高分", `${(supp.best ?? 0).toFixed(2)} (阈值 ${FAILURE_LOOKUP_MIN_CONFIDENCE})`);
+    }
+  }
+}
+
+// ---- 6. 漏警归因 ----------------------------------------------------------
+// The point of the telemetry: for each failure that happened, was there an
+// earlier lookup on the same target that could have warned and did not — and
+// which layer swallowed it. This is only answerable because the recorded
+// target is stored under the same normalization memory_tags uses.
+if (hasEvents) {
+  const misses = await db.all(`
+    SELECT e.outcome, COUNT(*) n
+      FROM memory_nodes f
+      JOIN memory_tags ft ON ft.nodeId = f.nodeId AND ft.tagType = 'file'
+      JOIN failure_lookup_events e
+        ON e.targetFileTag = ft.tagValue
+       AND e.createdAt < f.createdAt
+     WHERE f.kind = 'failure'
+       AND e.outcome <> 'injected'
+     GROUP BY e.outcome
+     ORDER BY n DESC
+  `);
+  const warned = await db.get(`
+    SELECT COUNT(DISTINCT f.nodeId) n
+      FROM memory_nodes f
+      JOIN memory_tags ft ON ft.nodeId = f.nodeId AND ft.tagType = 'file'
+      JOIN failure_lookup_events e
+        ON e.targetFileTag = ft.tagValue
+       AND e.createdAt < f.createdAt
+     WHERE f.kind = 'failure' AND e.outcome = 'injected'
+  `);
+  console.log("\n⑥ 漏警归因  —— 失败发生前，同目标的查找为什么没警告");
+  if (misses.length === 0 && !warned?.n) {
+    line("可归因的样本", "0（需要埋点上线后运行一段时间）");
+  } else {
+    line("失败前已警告过（警告未奏效）", warned?.n ?? 0);
+    for (const m of misses) line(`失败前查找过但 ${m.outcome}`, m.n);
+  }
+}
+
+await db.close();
+console.log("");

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -549,6 +549,63 @@ export async function runCodeMemoryMigrations(db: any): Promise<void> {
       WHERE sourceToolUseId IS NOT NULL
   `);
 
+  // Migration 26: Prior-failure lookup telemetry. The PreToolUse path is the
+  // product's headline behavior and was entirely unobservable: markUsed was
+  // never called from it, so useCount stayed 0 across every failure node and
+  // the database could not say whether a warning had ever fired. Worse, a
+  // silent lookup has four different causes — no target, no candidate, below
+  // the confidence floor, debounced — and they demand opposite fixes.
+  //
+  // A row per lookup, including the ones that surfaced nothing, is what makes
+  // recall measurable and lets an injection be joined against whatever failed
+  // afterwards.
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS failure_lookup_events (
+      eventId INTEGER PRIMARY KEY AUTOINCREMENT,
+      conversationId INTEGER,
+      sessionId TEXT,
+      toolName TEXT NOT NULL,
+      targetFile TEXT,
+      targetCommand TEXT,
+      targetFileTag TEXT,
+      targetCommandTag TEXT,
+      outcome TEXT NOT NULL CHECK(outcome IN (
+        'injected', 'debounced', 'below_confidence', 'no_candidates', 'no_target'
+      )),
+      candidateCount INTEGER NOT NULL DEFAULT 0,
+      passedCount INTEGER NOT NULL DEFAULT 0,
+      topScore REAL,
+      surfacedNodeIds TEXT,
+      source TEXT NOT NULL DEFAULT 'daemon',
+      createdAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+
+  await db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_failure_lookup_events_outcome ON failure_lookup_events(
+      outcome, createdAt
+    )
+  `);
+
+  // The joinable columns were added after the table shipped in a working
+  // branch, so upgrade in place rather than assuming a fresh database.
+  await addColumnIfMissing(db, "failure_lookup_events", "targetFileTag", "TEXT");
+  await addColumnIfMissing(db, "failure_lookup_events", "targetCommandTag", "TEXT");
+
+  // Indexed on the normalized forms: joining telemetry to memory_tags is the
+  // whole reason these columns exist, and the raw path cannot serve for it.
+  await db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_failure_lookup_events_target ON failure_lookup_events(
+      targetFileTag, createdAt
+    )
+  `);
+
+  await db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_failure_lookup_events_command ON failure_lookup_events(
+      targetCommandTag, createdAt
+    )
+  `);
+
   console.log(`[codememory] Database migrations completed successfully`);
 }
 

--- a/src/failure-lookup-cli.ts
+++ b/src/failure-lookup-cli.ts
@@ -36,6 +36,32 @@ async function main() {
 
     const toolInput = parseInputArg(rawToolInput);
     const response = await lookupForPreToolUse(memoryStore, toolName, toolInput);
+
+    // The cold path runs whenever the daemon is down, so leaving it
+    // uninstrumented would make recall look worse than it is exactly when the
+    // system is already degraded. Telemetry never blocks the tool call.
+    try {
+      await memoryStore.recordFailureLookup({
+        sessionId,
+        toolName,
+        targetFile: response.diagnostics.targetFile,
+        targetCommand: response.diagnostics.targetCommand,
+        targetFileTag: response.diagnostics.targetFileTag,
+        targetCommandTag: response.diagnostics.targetCommandTag,
+        outcome: response.diagnostics.outcome,
+        candidateCount: response.diagnostics.candidateCount,
+        passedCount: response.diagnostics.passedCount,
+        topScore: response.diagnostics.topScore,
+        surfacedNodeIds: response.diagnostics.surfacedNodeIds,
+        source: "cli",
+      });
+      if (response.shouldInject) {
+        await memoryStore.markUsed(response.diagnostics.surfacedNodeIds);
+      }
+    } catch {
+      // Measurement gap, not a user-visible failure.
+    }
+
     console.log(JSON.stringify(response));
   } catch (err) {
     console.error(`Error retrieving prior failures: ${err}`);

--- a/src/failure-lookup.ts
+++ b/src/failure-lookup.ts
@@ -9,6 +9,7 @@
  * matches must be filtered before injection.
  */
 
+import { qualifyFileTag, commandVariants } from "./retrieval-plan.js";
 import type {
   MemoryNodeStore,
   MemoryNodeRecord,
@@ -20,13 +21,42 @@ export interface FailureLookupResponse {
   reason: string;
   failures: FailureSurface[];
   markdown?: string;
+  /**
+   * Why this lookup did or did not surface anything.
+   *
+   * A silent PreToolUse has four distinct causes — no retrievable target, no
+   * stored candidate, everything below the confidence floor, or a debounce —
+   * and they call for opposite fixes. Without this the caller can only see
+   * "nothing was injected" and cannot tell which.
+   */
+  diagnostics: FailureLookupDiagnostics;
 }
 
-/**
- * Shape passed back to the hook layer. Mirrors what the hook script
- * cares about: a key it can use for anti-flood debounce + the rendered
- * markdown.
- */
+export interface FailureLookupDiagnostics {
+  outcome: "injected" | "below_confidence" | "no_candidates" | "no_target";
+  /** Raw path from the tool input — readable, but not comparable to tags. */
+  targetFile?: string;
+  targetCommand?: string;
+  /**
+   * The same targets under the exact normalization memory_tags uses, so a
+   * recorded lookup can be joined against the failures stored for that target.
+   *
+   * The raw path cannot: qualifyFileTag rewrites in-workspace paths to
+   * `<workspaceKey>:<relative>`, so `/abs/path/src/foo.ts` and the tag
+   * `abc12345:src/foo.ts` never match. Without these columns the telemetry can
+   * only report whether the mechanism ran, never whether a warning that was
+   * skipped should have fired.
+   */
+  targetFileTag?: string;
+  targetCommandTag?: string;
+  /** Nodes the anchor query returned, before scoring. */
+  candidateCount: number;
+  /** Of those, how many cleared MIN_CONFIDENCE. */
+  passedCount: number;
+  topScore?: number;
+  surfacedNodeIds: string[];
+}
+
 export interface FailureSurface {
   nodeId: string;
   type: string;
@@ -176,6 +206,12 @@ export async function lookupForPreToolUse(
       shouldInject: false,
       reason: "No retrievable target from tool input",
       failures: [],
+      diagnostics: {
+        outcome: "no_target",
+        candidateCount: 0,
+        passedCount: 0,
+        surfacedNodeIds: [],
+      },
     };
   }
 
@@ -187,11 +223,25 @@ export async function lookupForPreToolUse(
   });
 
   const now = Date.now();
-  const scored = candidates
+  // Score everything first: the highest score among *rejected* candidates is
+  // the number that says whether the floor is the thing suppressing recall.
+  const allScored = candidates
     .map(({ node }) => ({ node, score: scoreMatch(node, targets, now) }))
-    .filter(({ score }) => score >= MIN_CONFIDENCE)
-    .sort((a, b) => b.score - a.score)
-    .slice(0, options.limit ?? 2);
+    .sort((a, b) => b.score - a.score);
+  const passed = allScored.filter(({ score }) => score >= MIN_CONFIDENCE);
+  const scored = passed.slice(0, options.limit ?? 2);
+
+  const baseDiagnostics = {
+    targetFile: targets.filePath,
+    targetCommand: targets.command,
+    targetFileTag: targets.filePath ? qualifyFileTag(targets.filePath) : undefined,
+    targetCommandTag: targets.command
+      ? commandVariants(targets.command).slice(-1)[0]
+      : undefined,
+    candidateCount: candidates.length,
+    passedCount: passed.length,
+    topScore: allScored[0]?.score,
+  };
 
   if (scored.length === 0) {
     return {
@@ -201,6 +251,11 @@ export async function lookupForPreToolUse(
           ? `Filtered ${candidates.length} candidate(s) below confidence threshold`
           : "No prior failures for this target",
       failures: [],
+      diagnostics: {
+        ...baseDiagnostics,
+        outcome: candidates.length > 0 ? "below_confidence" : "no_candidates",
+        surfacedNodeIds: [],
+      },
     };
   }
 
@@ -210,6 +265,11 @@ export async function lookupForPreToolUse(
     reason: "Found relevant prior failures",
     failures,
     markdown: renderFailureMarkdown(failures),
+    diagnostics: {
+      ...baseDiagnostics,
+      outcome: "injected",
+      surfacedNodeIds: scored.map((s) => s.node.nodeId),
+    },
   };
 }
 

--- a/src/hooks/daemon.ts
+++ b/src/hooks/daemon.ts
@@ -25,6 +25,7 @@ import {
   flushExploredTargets,
 } from "../filter/explored-targets-store.js";
 import { NegExpExtractor } from "../negexp/extractor.js";
+import type { FailureLookupResponse } from "../failure-lookup.js";
 import { lookupForPreToolUse } from "../failure-lookup.js";
 import { RetrievalEngine } from "../retrieval.js";
 import { createSmartQueryPlanner } from "../query-planner.js";
@@ -183,6 +184,46 @@ async function startDaemon(args: string[]) {
         /* ignore */
       }
     }
+    /**
+     * Telemetry must never be able to break a tool call, so every failure here
+     * is swallowed. A missing row is a gap in measurement; a thrown error
+     * would be a blocked Edit.
+     */
+    const recordLookup = async (
+      body: any,
+      response: FailureLookupResponse,
+      outcome:
+        | "injected"
+        | "debounced"
+        | "below_confidence"
+        | "no_candidates"
+        | "no_target",
+      surfacedNodeIds: string[]
+    ): Promise<void> => {
+      try {
+        const conv = await conversationStore.getConversationForSession({
+          sessionId,
+        });
+        await memoryStore.recordFailureLookup({
+          conversationId: conv?.conversationId ?? null,
+          sessionId,
+          toolName: String(body?.toolName ?? "unknown"),
+          targetFile: response.diagnostics.targetFile,
+          targetCommand: response.diagnostics.targetCommand,
+          targetFileTag: response.diagnostics.targetFileTag,
+          targetCommandTag: response.diagnostics.targetCommandTag,
+          outcome,
+          candidateCount: response.diagnostics.candidateCount,
+          passedCount: response.diagnostics.passedCount,
+          topScore: response.diagnostics.topScore,
+          surfacedNodeIds,
+          source: "daemon",
+        });
+      } catch (err) {
+        logger.warn(`recordFailureLookup failed: ${err}`);
+      }
+    };
+
     const lookupServer = http.createServer((req, res) => {
       if (req.method !== "POST") {
         res.statusCode = 404;
@@ -412,6 +453,7 @@ async function startDaemon(args: string[]) {
               return last != null && now - last < WARN_DEBOUNCE_MS;
             });
             if (allRecent) {
+              await recordLookup(body, response, "debounced", keys);
               res.setHeader("content-type", "application/json");
               res.end(
                 JSON.stringify({
@@ -423,7 +465,22 @@ async function startDaemon(args: string[]) {
               return;
             }
             for (const k of keys) recentlyWarned.set(k, now);
+
+            // "Used" means actually surfaced to the model, so it is recorded
+            // here rather than at lookup time — a debounced hit is not a use.
+            try {
+              await memoryStore.markUsed(keys);
+            } catch (err) {
+              logger.warn(`markUsed failed: ${err}`);
+            }
           }
+
+          await recordLookup(
+            body,
+            response,
+            response.diagnostics.outcome,
+            response.diagnostics.surfacedNodeIds
+          );
 
           res.setHeader("content-type", "application/json");
           res.end(JSON.stringify(response));

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -1108,6 +1108,62 @@ export class MemoryNodeStore {
       .slice(0, input.limit ?? plan.recallPolicy.maxCandidates);
   }
 
+  /**
+   * Append one row per PreToolUse lookup, including the ones that surfaced
+   * nothing. The silent outcomes are the interesting ones: they separate
+   * "there was no prior failure to warn about" from "there was, and something
+   * suppressed it", which is the difference between a recall problem and a
+   * threshold problem.
+   */
+  async recordFailureLookup(input: {
+    conversationId?: number | null;
+    sessionId?: string | null;
+    toolName: string;
+    targetFile?: string | null;
+    targetCommand?: string | null;
+    /** Normalized forms, matching memory_tags, so this row can be joined. */
+    targetFileTag?: string | null;
+    targetCommandTag?: string | null;
+    outcome:
+      | "injected"
+      | "debounced"
+      | "below_confidence"
+      | "no_candidates"
+      | "no_target";
+    candidateCount: number;
+    passedCount: number;
+    topScore?: number | null;
+    surfacedNodeIds?: string[];
+    source?: "daemon" | "cli";
+  }): Promise<void> {
+    await this.db.run(
+      `INSERT INTO failure_lookup_events (
+         conversationId, sessionId, toolName, targetFile, targetCommand,
+         targetFileTag, targetCommandTag,
+         outcome, candidateCount, passedCount, topScore, surfacedNodeIds,
+         source, createdAt
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        input.conversationId ?? null,
+        input.sessionId ?? null,
+        input.toolName,
+        input.targetFile ?? null,
+        input.targetCommand ?? null,
+        input.targetFileTag ?? null,
+        input.targetCommandTag ?? null,
+        input.outcome,
+        input.candidateCount,
+        input.passedCount,
+        input.topScore ?? null,
+        input.surfacedNodeIds?.length
+          ? JSON.stringify(input.surfacedNodeIds)
+          : null,
+        input.source ?? "daemon",
+        new Date().toISOString(),
+      ]
+    );
+  }
+
   async markUsed(nodeIds: string[]): Promise<void> {
     if (nodeIds.length === 0) return;
     const now = new Date().toISOString();


### PR DESCRIPTION
Before measuring whether the warnings help, they have to be measurable at all. They are not.

## The gap

`markUsed` was never called from the PreToolUse path, so `useCount` sat at **0 across every stored failure node**. That says nothing about whether a warning ever fired — only that nobody recorded it.

```
kind         cumulative uses  nodes
summary      85               72     ← UserPromptSubmit path, instrumented
failure      0                45     ← the headline feature
fix_attempt  0                123
```

A silent lookup also has four distinct causes — no retrievable target, no stored candidate, everything below the confidence floor, a debounce — which call for **opposite fixes**. The caller could not tell them apart.

## What this adds

`failure_lookup_events`, one row per lookup **including the silent ones**, plus the diagnostics to fill it: candidate count before scoring, how many cleared the floor, and the top score among *rejected* candidates — the number that says whether the floor is what suppresses recall.

The target is stored twice: the raw path for reading, and the same value under `qualifyFileTag` / `commandVariants` for **joining**. Without the normalized form the telemetry cannot join `memory_tags` at all — `/abs/path/src/foo.ts` never matches the stored `abc12345:src/foo.ts` — and the only answerable question would be whether the mechanism ran, never whether a skipped warning should have fired.

`markUsed` now fires where a node is genuinely surfaced, **after** the debounce check. A debounced hit is recorded as such and does not count as a use. The cold-path CLI is instrumented too: it runs whenever the daemon is down, so leaving it out would make recall look worst exactly when the system is already degraded.

Every write is wrapped and swallowed. A missing row is a gap in measurement; a thrown error would be a blocked `Edit`.

## Retrospective baseline

`scripts/analyze-failure-recall.mjs` replays each stored failure's own anchors through the real `findFailuresByAnchors` and `scoreMatch` — not a reimplementation — and reads the live table once it has data.

| | |
|---|---|
| anchors | 84% carry a file tag; **16% carry none** and can never be recalled |
| signatures | median **330** chars, max 1891 — only **32%** under 120 |
| recall | **2 of 25** failures had an earlier match; **0** blocked by the floor |
| recurrence | 5 `reopen_failure` events, 3 signatures seen more than once |

**The zero is the useful part.** Lowering `MIN_CONFIDENCE`, widening the half-life, relaxing the debounce — none would change recall, because the floor is not what suppresses it. That contradicts the natural assumption and is only visible once the numbers exist.

The dominant limiter is elsewhere: `findFailuresByAnchors` queries `status='active'` while most nodes are auto-resolved within hours by a 50-seq staleness window, even though `reopen_failure` shows they do recur. That is a behavior change and deliberately **not** here — this PR only makes the effect measurable, so the fix can be judged against a baseline instead of a guess.

## Verification

- **290/290 tests pass**; `dist/` committed alongside source
- All four outcomes exercised against a live daemon:

```
outcome        toolName  targetFile          cand  pass  top
no_target      Read                          0     0
no_candidates  Edit      /tmp/never-seen.ts  0     0
injected       Edit      /tmp/seeded.ts      1     1     1.0
debounced      Edit      /tmp/seeded.ts      1     1     1.0
```

- `useCount` went `0 -> 1` on the injected call and stayed there through the debounced one
- Join verified end to end: recorded `targetFileTag` (`1361b098:src/app.ts`) matches the stored `memory_tags` value exactly, and the attribution query returns the linked failure node

🤖 Generated with [Claude Code](https://claude.com/claude-code)