### PR TITLE
release: 0.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codememory-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CodeMemory plugin for Claude Code CLI. Replaces traditional sliding-window conversation compaction with a DAG-based summarization system that preserves every message while maintaining active context within model token limits.",
   "author": {
     "name": "harry"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codememory-for-claude",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CodeMemory for Claude Code CLI",
   "type": "module",
   "main": "dist/plugin/index.js",


### PR DESCRIPTION
Version bump only. All the code shipped in #10 and #11.

`0.4.0` rather than `0.3.1`: this adds a table and a diagnostic surface, and changes what the extraction pass actually produces.

## What ships

Both fixes turned out to be about the same thing — **a subsystem that could not report on itself.**

### The prior-failure path is now observable (#10)

`markUsed` was never called from it, so `useCount` stayed at 0 across every stored failure node — which said nothing about whether a warning had ever fired. A silent lookup also has four causes that call for opposite fixes (no target, no candidate, below the confidence floor, debounced), and nothing distinguished them.

`failure_lookup_events` records one row per lookup **including the silent ones**, with the target stored under the same normalization `memory_tags` uses, so an injection can be joined against whatever failed afterwards.

The retrospective baseline that motivated it is worth restating:

| | |
|---|---|
| failures with an earlier match | **2 of 25** |
| blocked by the confidence floor | **0** |

Lowering `MIN_CONFIDENCE` would have changed nothing — the opposite of the obvious assumption, and invisible without the numbers.

### Key-memory extraction now works on real transcripts (#11)

It had been returning **zero** decisions from sessions that were entirely about making decisions. The instruction sat ahead of 24k characters of dialogue that ended mid-turn, so the model read the excerpt as a conversation to continue and replied in prose. Three of five chunks hit the timeout writing those replies.

The instruction moves after the excerpt, the role is pinned in the system prompt, and the excerpt is fenced so its turn markers read as quoted content.

On this session's own 4.6 MB transcript:

| | decisions | tasks | constraints |
|---|---|---|---|
| before | **0** | 0 | 0 |
| after | **20** | **12** | **6** |

Plus one supersede chain. The recovered set includes `--bare` disables keychain auth, use a `CODEMEMORY_CHILD` guard — knowledge that previously existed only as prose buried in summaries.

## Release checklist

- [x] `dist/` rebuilt — `npm run build` produces no diff
- [x] `290/290` tests pass
- [x] `claude plugin validate .` passes
- [x] `package.json` and `.claude-plugin/plugin.json` agree on `0.4.0`

After merge I'll run `claude plugin tag . --push` to create `codememory-plugin--v0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)